### PR TITLE
Fixing build on Linux

### DIFF
--- a/Parsers/CppParser/cppdocumentparser.cpp
+++ b/Parsers/CppParser/cppdocumentparser.cpp
@@ -29,7 +29,7 @@
 #include <coreplugin/icore.h>
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/actionmanager/actionmanager.h>
-#include <cpptools/CppModelManagerInterface.h>
+#include <cpptools/cppmodelmanagerinterface.h>
 #include <cpptools/cpptoolsreuse.h>
 #include <cpptools/cppdoxygen.h>
 #include <cplusplus/Overview.h>

--- a/Parsers/CppParser/cppparsersettings.cpp
+++ b/Parsers/CppParser/cppparsersettings.cpp
@@ -21,7 +21,7 @@
 #include "cppparsersettings.h"
 #include "cppparserconstants.h"
 
-#include "..\..\spellcheckerconstants.h"
+#include "spellcheckerconstants.h"
 
 using namespace SpellChecker::CppSpellChecker::Internal;
 using namespace SpellChecker::CppSpellChecker;

--- a/SpellCheckers/HunspellChecker/HunspellChecker.pri
+++ b/SpellCheckers/HunspellChecker/HunspellChecker.pri
@@ -13,6 +13,7 @@ FORMS += \
 
 win32-msvc*:HUNSPELL_LIB_NAME=libhunspell
 win32-g++  :HUNSPELL_LIB_NAME=hunspell
+linux-g++  :HUNSPELL_LIB_NAME=hunspell
 
 INCLUDEPATH += $${LOCAL_HUNSPELL_SRC_DIR}/
 LIBS        += -L$${LOCAL_HUNSPELL_LIB_DIR} -l$${HUNSPELL_LIB_NAME}

--- a/SpellCheckers/HunspellChecker/hunspellchecker.h
+++ b/SpellCheckers/HunspellChecker/hunspellchecker.h
@@ -21,7 +21,7 @@
 #ifndef SPELLCHECKER_INTERNAL_HUNSPELLCHECKER_H
 #define SPELLCHECKER_INTERNAL_HUNSPELLCHECKER_H
 
-#include "..\..\ISpellChecker.h"
+#include "ISpellChecker.h"
 
 #include <QObject>
 

--- a/spellchecker.pro
+++ b/spellchecker.pro
@@ -50,7 +50,7 @@ isEmpty(QTCREATOR_SOURCES):QTCREATOR_SOURCES=$${LOCAL_QTCREATOR_SOURCES}
 IDE_BUILD_TREE = $$(QTC_BUILD)
 isEmpty(IDE_BUILD_TREE):IDE_BUILD_TREE=$${LOCAL_IDE_BUILD_TREE}
 # Does not seem to need this one as it is added by Qt Creator already
-#include(spellchecker_dependencies.pri)
+include(spellchecker_dependencies.pri)
 
 ## uncomment to build plugin into user config directory
 ## <localappdata>/plugins/<ideversion>
@@ -59,6 +59,6 @@ isEmpty(IDE_BUILD_TREE):IDE_BUILD_TREE=$${LOCAL_IDE_BUILD_TREE}
 ##    "$XDG_DATA_HOME/data/QtProject/qtcreator" or "~/.local/share/data/QtProject/qtcreator" on Linux
 ##    "~/Library/Application Support/QtProject/Qt Creator" on Mac
 # USE_USER_DESTDIR = yes
-
+#
 PROVIDER = CJC
 include($$QTCREATOR_SOURCES/src/qtcreatorplugin.pri)


### PR DESCRIPTION
Fixing build on Linux machines. 
- Linux is case sensitive
- spellchecker_dependencies.pri needs to be explicitly added
- hunspell library for linux-g++
