### PR TITLE
Always spell-check current file.

### DIFF
--- a/Parsers/CppParser/cppdocumentparser.cpp
+++ b/Parsers/CppParser/cppdocumentparser.cpp
@@ -150,7 +150,7 @@ void CppDocumentParser::parseCppDocumentOnUpdate(CPlusPlus::Document::Ptr docPtr
             && (d->currentEditorFileName != fileName)) {
         return;
     }
-    if(shouldParseDocument(fileName) == false) {
+	if(d->currentEditorFileName != fileName && shouldParseDocument(fileName) == false) {
         return;
     }
     WordList words = parseCppDocument(docPtr);


### PR DESCRIPTION
Spell-check must be done for the current file even if it is not in startup project.
