### PR TITLE
Replace word in a single edit operation.

### DIFF
--- a/spellcheckercore.cpp
+++ b/spellcheckercore.cpp
@@ -468,10 +468,12 @@ void SpellCheckerCore::replaceWordsInCurrentEditor(const WordList &wordsToReplac
         editorWidget->gotoLine(wordToReplace.lineNumber, wordToReplace.columnNumber + wordToReplace.length - 1);
         int wordEndPos = editorWidget->textCursor().position();
 
+        cursor.beginEditBlock();
         cursor.setPosition(wordStartPos);
         cursor.setPosition(wordEndPos, QTextCursor::KeepAnchor);
         cursor.removeSelectedText();
         cursor.insertText(replacementWord);
+        cursor.endEditBlock();
     }
 }
 //--------------------------------------------------


### PR DESCRIPTION
This allows the replacement to be cancelled with a single UNDO command.
