### PR TITLE
Allow fixing spelling mistake through QuickFix.

### DIFF
--- a/spellchecker.pro
+++ b/spellchecker.pro
@@ -14,7 +14,8 @@ SOURCES += \
         spellcheckercoreoptionswidget.cpp \
         suggestionsdialog.cpp \
         NavigationWidget.cpp \
-        ProjectMistakesModel.cpp
+        ProjectMistakesModel.cpp \
+        spellcheckquickfix.cpp
 
 HEADERS += spellcheckerplugin.h\
         spellchecker_global.h\
@@ -30,7 +31,8 @@ HEADERS += spellcheckerplugin.h\
         spellcheckercoreoptionswidget.h \
         suggestionsdialog.h \
         NavigationWidget.h \
-        ProjectMistakesModel.h
+        ProjectMistakesModel.h \
+        spellcheckquickfix.h
 
 FORMS += \
         spellcheckercoreoptionswidget.ui \

--- a/spellchecker_dependencies.pri
+++ b/spellchecker_dependencies.pri
@@ -7,6 +7,7 @@ QTC_PLUGIN_DEPENDS += \
     coreplugin \
     texteditor \
     projectexplorer \
+    cppeditor \
     cpptools
 
 QTC_PLUGIN_RECOMMENDS += \

--- a/spellcheckercore.cpp
+++ b/spellcheckercore.cpp
@@ -302,7 +302,7 @@ ProjectMistakesModel *SpellCheckerCore::spellingMistakesModel() const
 }
 //--------------------------------------------------
 
-bool SpellCheckerCore::isWordUnderCursorMistake(Word& word)
+bool SpellCheckerCore::isWordUnderCursorMistake(Word& word) const
 {
     if(d->currentEditor.isNull() == true) {
         return false;

--- a/spellcheckercore.h
+++ b/spellcheckercore.h
@@ -84,6 +84,20 @@ public:
     Internal::SpellCheckerCoreSettings* settings() const;
     Internal::ProjectMistakesModel* spellingMistakesModel() const;
 
+    /*! \brief Is the Word Under the Cursor a Mistake
+     * Check if the word under the cursor is a spelling mistake, and if it is,
+     * return the misspelled word.
+     * \param[out] word If the word is a mistake, this will return the misspelled word.
+     * \return True if the word is misspelled.
+     */
+    bool isWordUnderCursorMistake(Word& word) const;
+    /*! \brief Replace Words In CurrentEditor.
+     * Replace the given words in the current editor with the supplied replacement word.
+     * \param[in] wordsToReplace List of words to replace
+     * \param[in] replacementWord Word to replace all occurrences of the \a wordsToReplace
+     *              with.
+     */
+    void replaceWordsInCurrentEditor(const WordList& wordsToReplace, const QString& replacementWord);
 
 private:
     enum RemoveAction {
@@ -91,13 +105,6 @@ private:
         Ignore,   /*!< Ignore the word for the current Qt Creator Session. */
         Add       /*!< Add the word to the user's custom dictionary. */
     };
-    /*! \brief Is the Word Under the Cursor a Mistake
-     * Check if the word under the cursor is a spelling mistake, and if it is,
-     * return the misspelled word.
-     * \param[out] word If the word is a mistake, this will return the misspelled word.
-     * \return True if the word is misspelled.
-     */
-    bool isWordUnderCursorMistake(Word& word);
     /*! \brief Get All Occurrences Of a Word.
      * \param[in] word Word that must be retrieved.
      * \param[out] List of words that are the same as the \a word.
@@ -109,13 +116,6 @@ private:
      * \param[in] action Action to use to remove the word.
      */
     void removeWordUnderCursor(RemoveAction action);
-    /*! \brief Replace Words In CurrentEditor.
-     * Replace the given words in the current editor with the supplied replacement word.
-     * \param[in] wordsToReplace List of words to replace
-     * \param[in] replacementWord Word to replace all occurrences of the \a wordsToReplace
-     *              with.
-     */
-    void replaceWordsInCurrentEditor(const WordList& wordsToReplace, const QString& replacementWord);
     
 signals:
     /*! \brief Signal emitted to inform the plugin if the word under the cursor is a mistake.

--- a/spellcheckerplugin.cpp
+++ b/spellcheckerplugin.cpp
@@ -21,6 +21,7 @@
 #include "spellcheckerplugin.h"
 #include "spellcheckerconstants.h"
 #include "spellcheckercore.h"
+#include "spellcheckquickfix.h"
 #include "outputpane.h"
 #include "NavigationWidget.h"
 
@@ -163,7 +164,12 @@ bool SpellCheckerPlugin::initialize(const QStringList &arguments, QString *error
     addAutoReleasedObject(cppParser);
     addAutoReleasedObject(cppParser->optionsPage());
 
-    m_spellCheckerCore->addDocumentParser(cppParser);  
+    m_spellCheckerCore->addDocumentParser(cppParser);
+
+    /* Quick fix provider */
+    SpellCheckCppQuickFixFactory* quickFixFactory = new SpellCheckCppQuickFixFactory;
+    addAutoReleasedObject(quickFixFactory);
+
     return true;
 }
 

--- a/spellcheckquickfix.cpp
+++ b/spellcheckquickfix.cpp
@@ -1,0 +1,122 @@
+/**************************************************************************
+**
+** Copyright (c) 2014 Carel Combrink
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include <cppeditor/cppeditor.h>
+#include "spellcheckquickfix.h"
+#include "spellcheckercore.h"
+
+using namespace SpellChecker;
+
+namespace SpellChecker {
+namespace Internal {
+
+class SpellCheckReplaceWordOperation : public TextEditor::QuickFixOperation
+{
+public:
+    SpellCheckReplaceWordOperation(const WordList &words, const QString &replacement):
+        m_words(words),
+        m_replacement(replacement)
+    {
+    }
+
+    QString description() const Q_DECL_OVERRIDE
+    {
+        return QString(QLatin1String("Replace with '%1'")).arg(m_replacement);
+    }
+
+    void perform() Q_DECL_OVERRIDE
+    {
+        SpellCheckerCore* core = SpellCheckerCore::instance();
+        if (core) {
+            core->replaceWordsInCurrentEditor(m_words, m_replacement);
+        }
+    }
+
+private:
+    WordList m_words;
+    QString m_replacement;
+};
+//--------------------------------------------------
+
+class SpellCheckIgnoreWordOperation : public TextEditor::QuickFixOperation
+{
+public:
+    QString description() const Q_DECL_OVERRIDE
+    {
+        return QLatin1String("Ignore word");
+    }
+
+    void perform() Q_DECL_OVERRIDE
+    {
+        SpellCheckerCore* core = SpellCheckerCore::instance();
+        if (core) {
+            core->ignoreWordUnderCursor();
+        }
+    }
+};
+//--------------------------------------------------
+
+class SpellCheckAddWordOperation : public TextEditor::QuickFixOperation
+{
+public:
+    QString description() const Q_DECL_OVERRIDE
+    {
+        return QLatin1String("Add word to dictionary");
+    }
+
+    void perform() Q_DECL_OVERRIDE
+    {
+        SpellCheckerCore* core = SpellCheckerCore::instance();
+        if (core) {
+            core->addWordUnderCursor();
+        }
+    }
+};
+
+}
+}
+
+//--------------------------------------------------
+
+void SpellCheckCppQuickFixFactory::match(const CppEditor::Internal::CppQuickFixInterface &interface, TextEditor::QuickFixOperations &result)
+{
+    Q_UNUSED(interface)
+
+    SpellCheckerCore* core = SpellCheckerCore::instance();
+    if (!core)
+        return;
+
+    Word word;
+    if (core->isWordUnderCursorMistake(word)) {
+        WordList words;
+        words.append(word);
+
+        int priority = word.suggestions.count();
+        result.reserve(word.suggestions.count() + 2);
+        foreach (const QString &suggestion, word.suggestions) {
+            TextEditor::QuickFixOperation *quickFix = new Internal::SpellCheckReplaceWordOperation(words, suggestion);
+            quickFix->setPriority(priority--);
+            result.append(TextEditor::QuickFixOperation::Ptr(quickFix));
+        }
+        result.prepend(TextEditor::QuickFixOperation::Ptr(new Internal::SpellCheckIgnoreWordOperation()));
+        result.prepend(TextEditor::QuickFixOperation::Ptr(new Internal::SpellCheckAddWordOperation()));
+    }
+}
+//--------------------------------------------------

--- a/spellcheckquickfix.h
+++ b/spellcheckquickfix.h
@@ -1,0 +1,43 @@
+/**************************************************************************
+**
+** Copyright (c) 2014 Carel Combrink
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#ifndef SPELLCHECKER_SPELLCHECKQUICKFIX_H
+#define SPELLCHECKER_SPELLCHECKQUICKFIX_H
+
+#include <cppeditor/cppquickfix.h>
+
+namespace SpellChecker {
+
+/*!
+ * \brief QuickFixFactory implementation for fixing spelling mistakes inside C++ editor.
+ *
+ * It would be more generic to implement TextEditor::QuickFixFactory, but each editor actually only
+ * uses a single quick fix factory at the moment (QtCreator 3.2); thus for C++ a CppQuickFixFactory
+ * must be created instead.
+ */
+class SpellCheckCppQuickFixFactory: public CppEditor::CppQuickFixFactory
+{
+public:
+    void match(const CppEditor::Internal::CppQuickFixInterface &interface, TextEditor::QuickFixOperations &result) Q_DECL_OVERRIDE;
+};
+
+}
+
+#endif // SPELLCHECKER_SPELLCHECKQUICKFIX_H


### PR DESCRIPTION
When quickfix (alt+return) is invoked on a spelling mistake, all suggestions are shown in the
quickfix menu.