### PR TITLE
Added .cc to the list of C++ file name extensions

### DIFF
--- a/Parsers/CppParser/cppparserconstants.h
+++ b/Parsers/CppParser/cppparserconstants.h
@@ -33,7 +33,7 @@ const char WEBSITE_ADDRESS_REGEXP_PATTERN[] = "((http(s)?):\\/\\/)?(\\w+\\.){1,1
 /* Pattern for characters that can be part of a website URL. */
 const char WEBSITE_CHARS_REGEXP_PATTERN[]   = "[/:\\?=#%-]";
 /* Pattern for CPP files. */
-const char CPP_SOURCE_FILES_REGEXP_PATTERN[]= ".*\\.(c|cpp|h|hpp|dox)$";
+const char CPP_SOURCE_FILES_REGEXP_PATTERN[]= ".*\\.(c|cc|cpp|h|hpp|dox)$";
 
 const char CPP_PARSER_GROUP[]       = "CppParser";
 const char WHAT_TO_CHECK[]          = "WhatToCheck";


### PR DESCRIPTION
I believe that .cc is a quite common file extension for C++ files, at least I use it a lot.
I have added  it to the list of patterns to match for C++ files.
I tested it with my own build of the plugin and it now works with my C++ files.
