### PR TITLE
Avoid 'blocking' the IDE main thread in outputpane

### DIFF
--- a/outputpane.h
+++ b/outputpane.h
@@ -108,9 +108,9 @@ public:
 private:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
     void setEditorData(QWidget *editor, const QModelIndex &index) const Q_DECL_OVERRIDE;
     void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const Q_DECL_OVERRIDE;
-    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 signals:
     /*! \brief Signal emitted when the user clicks on one of the suggestions buttons.
      *


### PR DESCRIPTION
When a file has many errors, the outpane ends up blocking the UI due to
multiple things:
* The non-uniform row height causes very slow layout update when the
selected item changes
* The automatic resizing of the column width

To overcome this, I disabled these two features. The buttons are now
rendered with a simpler, flatter style, which fits in the cell. Position
of each button seems to match approximately with the position of the
underlying text.

The column are now manually resizable, with sensible defaults. The index
column has also been removed (to spare a few pixels), as it does not add
any useful information for the user.

The code was also updated to handle cases with many proposals, to allowg
the layout to overlap the next columns instead of compressing the text
in each button.