### PR TITLE
Remove the experimental flag

### DIFF
--- a/SpellChecker.json.in
+++ b/SpellChecker.json.in
@@ -2,7 +2,6 @@
     \"Name\" : \"SpellChecker\",
     \"Version\" : \"0.16.0\",
     \"CompatVersion\" : \"0.16.0\",
-    \"Experimental\" : true,
     \"Vendor\" : \"Carel Combrink\",
     \"Copyright\" : \"(C) 2015 - 2017 Carel Combrink\",
     \"License\" : [ \"GNU Lesser General Public License Usage\",


### PR DESCRIPTION
If the user built and/or installed this plugin, there's no reason to
disable it by default.

If/when the plugin is intended to go upstream this will make more sense.