### PR TITLE
Add support for newer qtcreator versions, and support more CamelCase cases.

### DIFF
--- a/Parsers/CppParser/cppdocumentparser.cpp
+++ b/Parsers/CppParser/cppdocumentparser.cpp
@@ -660,8 +660,9 @@ void CppDocumentParser::applySettingsToWords(const QString &string, WordList &wo
             /* The check is not precise and accurate science, but a rough estimation of the word is in camelCase. This
              * will probably be updated as this gets tested. The current check checks for one or more lower case letters,
              * followed by one or more upper-case letter, followed by a lower case letter */
-            static const QRegularExpression camelCaseContainsRe(QLatin1String("[a-z]{1,}[A-Z]{1,}[a-z]{1,}"));
-            static const QRegularExpression camelCaseIndexRe(QLatin1String("[a-z][A-Z]"));
+            static const QRegularExpression camelCaseContainsRe(QLatin1String("(^[A-Z][A-Z]{1,}[a-z]{1,})"
+                                                                              "|([a-z]{1,}[A-Z]{1,})"));
+            static const QRegularExpression camelCaseIndexRe(QLatin1String("(^[A-Z][A-Z])|([a-z][A-Z])"));
             if(currentWord.contains(camelCaseContainsRe) == true ) {
                 if(d->settings->camelCaseWordOption == CppParserSettings::RemoveWordsInCamelCase) {
                     removeCurrentWord = true;

--- a/Parsers/CppParser/cppdocumentparser.cpp
+++ b/Parsers/CppParser/cppdocumentparser.cpp
@@ -266,6 +266,18 @@ WordList CppDocumentParser::parseCppDocument(CPlusPlus::Document::Ptr docPtr)
 
                 /* The String Literal is not expanded thus handle it like a comment is handled. */
                 parseToken(docPtr, token, trUnit, wordsInSource, /* Comment */ false, /* Doxygen */ false, parsedWords, tokenHashesIn, tokenHashesOut);
+            } else if (token.is (CPlusPlus::T_IDENTIFIER)) {
+                /* Parse T_IDENTIFIER tokens. For some reason, in qtcreator master,
+                   it would only parse comments. That should fix that */
+                parseToken(docPtr,
+                           token,
+                           trUnit,
+                           wordsInSource,
+                           /* Comment */ false,
+                           /* Doxygen */ false,
+                           parsedWords,
+                           tokenHashesIn,
+                           tokenHashesOut);
             }
         }
         /* Parse macros */

--- a/spellcheckerplugin.h
+++ b/spellcheckerplugin.h
@@ -21,8 +21,32 @@
 #pragma once
 
 #include "spellchecker_global.h"
+#include "spellcheckerconstants.h"
+#include "spellcheckercore.h"
+#include "spellcheckquickfix.h"
+#include "outputpane.h"
+#include "NavigationWidget.h"
+
+/* SpellCheckers */
+#include "SpellCheckers/HunspellChecker/hunspellchecker.h"
+
+
+#include <memory>
 
 #include <extensionsystem/iplugin.h>
+
+/* Parsers */
+#include "Parsers/CppParser/cppdocumentparser.h"
+#include "Parsers/CppParser/cppparsersettings.h"
+
+#include <coreplugin/dialogs/ioptionspage.h>
+#include <coreplugin/icore.h>
+#include <coreplugin/icontext.h>
+#include <coreplugin/actionmanager/actionmanager.h>
+#include <coreplugin/actionmanager/command.h>
+#include <coreplugin/actionmanager/actioncontainer.h>
+#include <coreplugin/coreconstants.h>
+#include <texteditor/texteditorconstants.h>
 
 namespace SpellChecker {
 class SpellCheckerCore;
@@ -50,8 +74,14 @@ public:
     void extensionsInitialized();
     ShutdownFlag aboutToShutdown();
 private:
-    SpellCheckerCore* m_spellCheckerCore;
-    CppSpellChecker::Internal::CppParserSettings* m_cppParserSettings;
+    std::unique_ptr<NavigationWidgetFactory> m_navigationWidgetFactory;
+    std::unique_ptr<SpellCheckCppQuickFixFactory> m_spellCheckCppQuickFixFactory;
+
+    std::unique_ptr<SpellChecker::CppSpellChecker::Internal::CppDocumentParser> m_cppParser;
+
+    std::unique_ptr<SpellCheckerCore> m_spellCheckerCore;
+    std::unique_ptr<CppSpellChecker::Internal::CppParserSettings> m_cppParserSettings;
+    std::unique_ptr<SpellChecker::Checker::Hunspell::HunspellChecker> m_spellChecker;
 };
 
 } // namespace Internal


### PR DESCRIPTION
First of all, thanks for this fantastic plugin. It made my life a lot more easier. 

I am using qtcreator master and I had a few problems:
 1. The plugin would not compile for me because it was using removed qtcreator methods (
346cf45)
 2. The plugin would only spellcheck comments; I could not find the code that does the actual code parsing so I've added mine (
9b7bb5d).

I've also improved the CamelCase splitting to support cases like `IBeautifulInterface ` and `invalidID`.

Thank you :D