### PR TITLE
Use Utils::Id instead of Core::Id.

### DIFF
--- a/src/spellcheckercore.cpp
+++ b/src/spellcheckercore.cpp
@@ -257,7 +257,7 @@ void SpellCheckerCore::addMisspelledWords( const QString& fileName, const WordLi
     selection.format = format;
     selections.append( selection );
   }
-  editorWidget->setExtraSelections( Core::Id( SpellChecker::Constants::SPELLCHECK_MISTAKE_ID ), selections );
+  editorWidget->setExtraSelections( Utils::Id( SpellChecker::Constants::SPELLCHECK_MISTAKE_ID ), selections );
 
   /* The model updated, check if the word under the cursor is now a mistake
    * and notify the rest of the checker with this information. */


### PR DESCRIPTION
Core::Id was moved to Utils::Id in qt-creator 1b431fe271e04b111d475654c7ea003981cba989.
This fixes the build failure when building against qt-creator 4.13.1.