### PR TITLE
build.yaml: fixed two typos

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           body: |
             Release for Qt Creator ${{env.QT_CREATOR_VERSION}}.
 
-            Download the correct file based on Operating system and architect of Qt Creator.
+            Download the correct file based on operating system and architecture of Qt Creator.
 
             To deploy into Qt Creator, extract the archive into the root folder of where Qt Creator is installed.
 


### PR DESCRIPTION
Minor change. Maybe double spaces shall be added to each line-ending for the "body"-part, because in the final release page the text shows up without any newlines. But looking at the yaml I guess they are wanted.