### PR TITLE
Add first CMake build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,104 @@
+# to configure run something like
+# cmake "-DCMAKE_PREFIX_PATH=<path_to_qt>;<path_to_qtcreator>;<path_to_hunspell>" -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja
+
+cmake_minimum_required(VERSION 3.10)
+
+## Add paths to check for cmake modules:
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+project(SpellChecker)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(QtCreator COMPONENTS Core REQUIRED)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+set(QtX Qt${QT_VERSION_MAJOR})
+
+add_qtc_plugin(SpellChecker
+  PLUGIN_DEPENDS
+    QtCreator::Core
+    QtCreator::TextEditor
+    QtCreator::ProjectExplorer
+    QtCreator::CppEditor
+  DEPENDS
+    ${QtX}::Widgets
+    QtCreator::ExtensionSystem
+    QtCreator::Utils
+  SOURCES
+    .github/workflows/build.yaml
+    COPYING
+    COPYING.LESSER
+    LICENSE
+    README.md
+    uncrustify.cfg
+)
+
+extend_qtc_plugin(SpellChecker
+  SOURCES_PREFIX src
+  SOURCES
+    ISpellChecker.cpp
+    ISpellChecker.h
+    NavigationWidget.cpp
+    NavigationWidget.h
+    ProjectMistakesModel.cpp
+    ProjectMistakesModel.h
+    Word.h
+    idocumentparser.cpp
+    idocumentparser.h
+    outputpane.cpp
+    outputpane.h
+    spellchecker_global.h
+    spellcheckerconstants.h
+    spellcheckercore.cpp
+    spellcheckercore.h
+    spellcheckercoreoptionspage.cpp
+    spellcheckercoreoptionspage.h
+    spellcheckercoreoptionswidget.cpp
+    spellcheckercoreoptionswidget.h
+    spellcheckercoreoptionswidget.ui
+    spellcheckercoresettings.cpp
+    spellcheckercoresettings.h
+    spellcheckerplugin.cpp
+    spellcheckerplugin.h
+    spellcheckquickfix.cpp
+    spellcheckquickfix.h
+    spellingmistakesmodel.cpp
+    spellingmistakesmodel.h
+    suggestionsdialog.cpp
+    suggestionsdialog.h
+    suggestionsdialog.ui
+)
+
+extend_qtc_plugin(SpellChecker
+  SOURCES_PREFIX src/Parsers/CppParser
+  SOURCES
+     cppdocumentparser.cpp
+     cppdocumentparser.h
+     cppdocumentprocessor.cpp
+     cppdocumentprocessor.h
+     cppparserconstants.h
+     cppparseroptionspage.cpp
+     cppparseroptionspage.h
+     cppparseroptionswidget.cpp
+     cppparseroptionswidget.h
+     cppparseroptionswidget.ui
+     cppparsersettings.cpp
+     cppparsersettings.h
+)
+
+find_package(hunspell)
+extend_qtc_plugin(SpellChecker
+  CONDITION TARGET hunspell::hunspell
+  DEPENDS hunspell::hunspell
+  SOURCES_PREFIX src/SpellCheckers/HunspellChecker/
+  SOURCES
+    HunspellConstants.h
+    hunspellchecker.cpp
+    hunspellchecker.h
+    hunspelloptionswidget.cpp
+    hunspelloptionswidget.h
+    hunspelloptionswidget.ui
+)

--- a/cmake/Findhunspell.cmake
+++ b/cmake/Findhunspell.cmake
@@ -1,0 +1,39 @@
+if(TARGET hunspell)
+  return()
+endif()
+
+find_path(HUNSPELL_INCLUDE_DIR
+  NAME hunspell/hunspell.hxx
+  PATH_SUFFIXES include
+  HINTS "${HUNSPELL_INSTALL_DIR}" ENV HUNSPELL_INSTALL_DIR "${CMAKE_PREFIX_PATH}"
+)
+
+find_library(HUNSPELL_LIB
+  NAMES libhunspell-1.7.a hunspell-1.7
+  PATH_SUFFIXES lib
+  HINTS "${HUNSPELL_INSTALL_DIR}" ENV HUNSPELL_INSTALL_DIR "${CMAKE_PREFIX_PATH}"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(hunspell
+  DEFAULT_MSG HUNSPELL_INCLUDE_DIR HUNSPELL_LIB
+)
+
+if(hunspell_FOUND)
+  if (NOT TARGET hunspell::hunspell)
+    add_library(hunspell::hunspell UNKNOWN IMPORTED)
+    set_target_properties(hunspell::hunspell
+      PROPERTIES
+        IMPORTED_LOCATION "${HUNSPELL_LIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${HUNSPELL_INCLUDE_DIR}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(HUNSPELL_INCLUDE_DIR HUNSPELL_LIB)
+
+include(FeatureSummary)
+set_package_properties(hunspell PROPERTIES
+  URL "https://hunspell.github.io"
+  DESCRIPTION "Hunspell spell checker"
+)


### PR DESCRIPTION
The "NAMES" for "find_library(HUNSPELL_LIB ...." in Findhunspell.cmake probably need some adaption for Windows and possibly when building against Linux distributions. I only tested that search mechanism on macOS with hunspell from HomeBrew.