### PR TITLE
Fix debug build error

### DIFF
--- a/src/spellcheckercoreoptionswidget.cpp
+++ b/src/spellcheckercoreoptionswidget.cpp
@@ -115,7 +115,7 @@ void SpellCheckerCoreOptionsWidget::updateWithSettings( const SpellCheckerCoreSe
     index = ui->comboBoxSpellChecker->findText( settings->activeSpellChecker );
     if( index == -1 ) {
       qDebug() << "Spellchecker from settings not valid option: " << settings->activeSpellChecker;
-      Q_ASSERT_X( false, "updateWithSettings", "Spellchecker from settings not valid option: " + settings->activeSpellChecker.toLatin1() );
+      Q_ASSERT_X( false, "updateWithSettings", ("Spellchecker from settings not valid option: " + settings->activeSpellChecker).toLatin1() );
       return;
     }
   }


### PR DESCRIPTION
```
../../spellchecker/src/spellcheckercoreoptionswidget.cpp: In member function ‘void SpellChecker::Internal::SpellCheckerCoreOptionsWidget::updateWithSettings(const SpellChecker::Internal::SpellCheckerCoreSettings*)’:
../../../qt5152/include/QtCore/qglobal.h:865:119: error: cannot convert ‘QStringBuilder<char [46], QByteArray>’ to ‘const char*’ for argument ‘2’ to ‘void qt_assert_x(const char*, const char*, const char*, int)’
 #    define Q_ASSERT_X(cond, where, what) ((cond) ? static_cast<void>(0) : qt_assert_x(where, what, __FILE__, __LINE__))
                                                                                                                       ^
../../spellchecker/src/spellcheckercoreoptionswidget.cpp:118:7: note: in expansion of macro ‘Q_ASSERT_X’
       Q_ASSERT_X( false, "updateWithSettings", "Spellchecker from settings not valid option: " + settings->activeSpellChecker.toLatin1() );
       ^~~~~~~~~~
make: *** [Makefile:5574: .obj/debug-shared/spellcheckercoreoptionswidget.o] Error 1

```

Move QStringBuilder in a sub-expression.