### PR TITLE
Update build.yaml for get release for Linux and Mac

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,8 +10,8 @@ name: Build SpellChecker-Plugin
 on: [push]
 
 env:
-  QT_VERSION: "6.4.2"
-  QT_CREATOR_VERSION: "11.0.0"
+  QT_VERSION: "6.4.3"
+  QT_CREATOR_VERSION: "11.0.1"
   QT_MIRRORS: download.qt.io;mirrors.ocf.berkeley.edu/qt;ftp.fau.de/qtproject;mirror.bit.edu.cn/qtproject
 
 # The Jobs


### PR DESCRIPTION
Update build.yaml for get release for Linux and Mac with update version of Qt into 6.4.3 and Qt creator into 11.0.1 but has problem in building in windows that should be related into version of Qt in vcpkg