### PR TITLE
Update build.yaml for get release for Linux and Mac

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on: [push]
 
 env:
   QT_VERSION: "6.5.2"
-  QT_CREATOR_VERSION: "12.0.0"
+  QT_CREATOR_VERSION: "12.0.0-beta1"
   QT_MIRRORS: download.qt.io;mirrors.ocf.berkeley.edu/qt;ftp.fau.de/qtproject;mirror.bit.edu.cn/qtproject
 
 # The Jobs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,8 +10,8 @@ name: Build SpellChecker-Plugin
 on: [push]
 
 env:
-  QT_VERSION: "6.4.2"
-  QT_CREATOR_VERSION: "11.0.0"
+  QT_VERSION: "6.4.3"
+  QT_CREATOR_VERSION: "11.0.1"
   QT_MIRRORS: download.qt.io;mirrors.ocf.berkeley.edu/qt;ftp.fau.de/qtproject;mirror.bit.edu.cn/qtproject
 
 # The Jobs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,7 +196,7 @@ jobs:
         shell: cmake -P {0}
         run: |
           string(REGEX MATCH "([0-9]+.[0-9]+).[0-9]+" outvar "$ENV{QT_CREATOR_VERSION}")
-          set(qtc_base_url "https://download.qt.io/official_releases/qtcreator/${CMAKE_MATCH_1}/$ENV{QT_CREATOR_VERSION}/installer_source")
+          set(qtc_base_url "https://download.qt.io/development_releases/qtcreator/${CMAKE_MATCH_1}/$ENV{QT_CREATOR_VERSION}/installer_source")
           set(qtc_snapshot "$ENV{QT_CREATOR_SNAPSHOT}")
           if (qtc_snapshot)
             set(qtc_base_url "https://download.qt.io/snapshots/qtcreator/${CMAKE_MATCH_1}/$ENV{QT_CREATOR_VERSION}/installer_source/${qtc_snapshot}")

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,8 +10,8 @@ name: Build SpellChecker-Plugin
 on: [push]
 
 env:
-  QT_VERSION: "6.4.3"
-  QT_CREATOR_VERSION: "11.0.1"
+  QT_VERSION: "6.5.2"
+  QT_CREATOR_VERSION: "12.0.0"
   QT_MIRRORS: download.qt.io;mirrors.ocf.berkeley.edu/qt;ftp.fau.de/qtproject;mirror.bit.edu.cn/qtproject
 
 # The Jobs

--- a/SpellChecker.json.in
+++ b/SpellChecker.json.in
@@ -12,7 +12,7 @@
                       \"An Output Pane, Right Click context menu and a Navigation Widget is added to QtCreator to interact with the results from this plugin.\"
     ],
     \"Url\" : \"https://github.com/CJCombrink/SpellChecker-Plugin\",
-    $$dependencyList,
+     ${IDE_PLUGIN_DEPENDENCIES}, ${IDE_VERSION},
 
     \"Mimetypes\" : [
         \"<?xml version=\'1.0\' encoding=\'UTF-8\'?>\",


### PR DESCRIPTION
Update build.yaml for get release for Linux and Mac with update version of Qt into 6.4.3 and Qt creator into 11.0.1 but has problem in building in windows that should be related into version of Qt in vcpkg