### PR TITLE
Use ubuntu-20.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
             }
           - {
               name: "linux",
-              os: ubuntu-22.04,
+              os: ubuntu-20.04,
               sys: "linux",
               arch: "x64",
               qt_arch: "",


### PR DESCRIPTION
I have problems using the precompiled releases on RedHat 8 because of  a `GLIBCXX_3.4.29` dependency. The precompiled QtCreator 16 was able to be run on that OS.

Aim of this PR is to use an not so top-notch OS to compile to avoid unnecessary dependencies. I think it is better to bump the compile image when there is a clear benefit to do so and therefore support a wider range of users.