### PR TITLE
Adapted initialize method to new signature

### DIFF
--- a/src/spellcheckerplugin.cpp
+++ b/src/spellcheckerplugin.cpp
@@ -102,7 +102,7 @@ SpellCheckerPlugin::~SpellCheckerPlugin()
   delete d;
 }
 
-bool SpellCheckerPlugin::initialize( const QStringList& arguments, QString* errorString )
+Utils::Result<> SpellCheckerPlugin::initialize(const QStringList& arguments)
 {
   // Create the core
   // Load settings
@@ -112,7 +112,6 @@ bool SpellCheckerPlugin::initialize( const QStringList& arguments, QString* erro
   // depends on have initialized their members.
 
   Q_UNUSED( arguments )
-  Q_UNUSED( errorString )
 #ifdef DEBUG_INSTALL_MESSAGE_HANDLER
   qInstallMessageHandler( myMessageOutput );
 #endif /* DEBUG_INSTALL_MESSAGE_HANDLER */
@@ -189,7 +188,7 @@ bool SpellCheckerPlugin::initialize( const QStringList& arguments, QString* erro
   /* Quick fix provider */
   d->quickFixFactory = std::make_unique<SpellCheckCppQuickFixFactory>();
 
-  return true;
+  return Utils::ResultOk;
 }
 
 void SpellCheckerPlugin::extensionsInitialized()

--- a/src/spellcheckerplugin.h
+++ b/src/spellcheckerplugin.h
@@ -47,7 +47,7 @@ public:
   SpellCheckerPlugin();
   ~SpellCheckerPlugin();
 
-  bool initialize( const QStringList& arguments, QString* errorString );
+  Utils::Result<> initialize(const QStringList& arguments);
   void extensionsInitialized();
   ShutdownFlag aboutToShutdown();
 private:

--- a/src/spellcheckerplugin.h
+++ b/src/spellcheckerplugin.h
@@ -47,9 +47,10 @@ public:
   SpellCheckerPlugin();
   ~SpellCheckerPlugin();
 
-  Utils::Result<> initialize(const QStringList& arguments);
-  void extensionsInitialized();
-  ShutdownFlag aboutToShutdown();
+  Utils::Result<> initialize(const QStringList& arguments) override;
+  void extensionsInitialized() override;
+  ShutdownFlag aboutToShutdown() override;
+
 private:
   SpellCheckerPluginPrivate* const d;
 };


### PR DESCRIPTION
Qt Creator 17 has a different signature to the initialize method. I removed the pointer to the error string and fixed the return value type. The return value is changed to Ok (was true before).