### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -2582,28 +2582,28 @@ pp_define_at_level              = false    # true/false
 pp_ignore_define_body           = false    # true/false
 
 # Whether to indent case statements between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the case statements
+# Only applies to the indent of the preprocessor that the case statements
 # directly inside of.
 #
 # Default: true
 pp_indent_case                  = true     # true/false
 
 # Whether to indent whole function definitions between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the function definition
+# Only applies to the indent of the preprocessor that the function definition
 # is directly inside of.
 #
 # Default: true
 pp_indent_func_def              = true     # true/false
 
 # Whether to indent extern C blocks between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the extern block is
+# Only applies to the indent of the preprocessor that the extern block is
 # directly inside of.
 #
 # Default: true
 pp_indent_extern                = true     # true/false
 
 # Whether to indent braces directly inside #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the braces are directly
+# Only applies to the indent of the preprocessor that the braces are directly
 # inside of.
 #
 # Default: true


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>