### PR TITLE
feat(qml): add first-class spell checking for QML files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_STANDARD 20)
 find_package(QtCreator COMPONENTS Core REQUIRED)
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
 set(QtX Qt${QT_VERSION_MAJOR})
+find_package(${QtX} COMPONENTS Widgets Test REQUIRED)
 
 message(STATUS "Using Qt Creator from: ${QtCreator_DIR}")
 
@@ -28,9 +29,11 @@ add_qtc_plugin(SpellChecker
     QtCreator::TextEditor
     QtCreator::ProjectExplorer
     QtCreator::CppEditor
+    QtCreator::QmlJSEditor
   DEPENDS
     ${QtX}::Widgets
     QtCreator::ExtensionSystem
+    QtCreator::QmlJS
     QtCreator::Utils
   SOURCES
     .github/workflows/build.yaml
@@ -94,6 +97,38 @@ extend_qtc_plugin(SpellChecker
      cppparsersettings.cpp
      cppparsersettings.h
 )
+
+extend_qtc_plugin(SpellChecker
+  SOURCES_PREFIX src/Parsers/QmlParser
+  SOURCES
+     qmldocumentparser.cpp
+     qmldocumentparser.h
+     qmldocumentprocessor.cpp
+     qmldocumentprocessor.h
+     qmlparserconstants.h
+     qmlparseroptionspage.cpp
+     qmlparseroptionspage.h
+     qmlparseroptionswidget.cpp
+     qmlparseroptionswidget.h
+     qmlparsersettings.cpp
+     qmlparsersettings.h
+)
+
+include(CTest)
+if(BUILD_TESTING)
+  add_executable(tst_qmldocumentprocessor
+    tests/qmlparser/tst_qmldocumentprocessor.cpp
+    src/Parsers/QmlParser/qmldocumentprocessor.cpp
+    src/Parsers/QmlParser/qmlparsersettings.cpp
+  )
+  target_link_libraries(tst_qmldocumentprocessor
+    PRIVATE
+      ${QtX}::Test
+      ${QtX}::Core
+      QtCreator::Utils
+  )
+  add_test(NAME tst_qmldocumentprocessor COMMAND tst_qmldocumentprocessor)
+endif()
 
 find_package(hunspell)
 extend_qtc_plugin(SpellChecker

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The SpellChecker Plugin is a spellchecker plugin for the Qt Creator IDE.
 This plugin spell checks Comments and String Literals in source files for spelling mistakes and suggests the correct spelling for misspelled words, if possible.
 
-Currently the plugin only checks C++ files and uses the Hunspell Spell Checker to check words for spelling mistakes.
+Currently the plugin checks C++ and QML files and uses the Hunspell Spell Checker to check words for spelling mistakes.
 The plugin provides an options page in Qt Creator that can be used to configure the parsers as well as the spell checkers available.
 
 To download a pre-built version of the plugin, refer to section 2.
@@ -101,6 +101,20 @@ The parser also has settings that affect how the following types of words will b
 - First comment in file (File license headers)
 
 Apart from these settings, the plugin also attempts to remove Doxygen Tags in Doxygen comments, in an effort to reduce the number of false positives.
+
+### 5.4. QML Document Parser
+
+The QML parser checks `.qml` files. It extracts words from:
+
+- `//` line comments
+- `/* ... */` block comments
+- single-quoted, double-quoted, and template string literals
+
+The parser intentionally ignores QML and JavaScript code tokens such as imports, ids, property names, bindings, and component names. It also filters common false positives such as URLs, email addresses, numbers, color-like values, and all-caps words by default.
+
+The QML parser has its own options page under "*Tools*" -> "*Options...*" -> "*Spell Checker*" -> "*QML Parser*". Comments and string literals can be enabled independently.
+
+The current implementation is a focused lexical parser. It reparses QML files when they become the current editor, when a QML file is saved, when project files change, and when parser settings change.
 
 ## 6. Building The Plugin
 

--- a/SpellChecker.json.in
+++ b/SpellChecker.json.in
@@ -1,7 +1,7 @@
 {
     "Id" : "spellchecker",
     "Name" : "SpellChecker",
-    "Version" : "3.12.1",
+    "Version" : "3.12.2",
     "CompatVersion" : "3.12.0",
     "VendorId" : "carel_combrink",
     "Vendor" : "Carel Combrink",

--- a/src/Parsers/QmlParser/qmldocumentparser.cpp
+++ b/src/Parsers/QmlParser/qmldocumentparser.cpp
@@ -1,0 +1,380 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include "qmldocumentparser.h"
+
+#include "../../spellcheckerconstants.h"
+#include "../../spellcheckercore.h"
+#include "../../spellcheckercoresettings.h"
+#include "qmldocumentprocessor.h"
+#include "qmlparseroptionspage.h"
+
+#include <coreplugin/editormanager/editormanager.h>
+#include <coreplugin/actionmanager/actioncontainer.h>
+#include <coreplugin/actionmanager/actionmanager.h>
+#include <coreplugin/icore.h>
+#include <coreplugin/idocument.h>
+#include <qmljseditor/qmljseditorconstants.h>
+#include <projectexplorer/project.h>
+#include <texteditor/textdocument.h>
+#include <utils/algorithm.h>
+#include <utils/async.h>
+#include <utils/filepath.h>
+#include <utils/mimeutils.h>
+
+#include <QApplication>
+#include <QFile>
+#include <QFutureWatcher>
+#include <QHash>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QTextStream>
+#include <QThread>
+#include <QThreadPool>
+#include <QTimer>
+
+using namespace SpellChecker;
+using namespace SpellChecker::QmlSpellChecker::Internal;
+
+namespace {
+
+/*! \brief Query whether a file should be treated as QML.
+ * \param[in] fileName File path to classify.
+ * \return true for QML mime type or `.qml` suffix. */
+bool isQmlFile( const QString& fileName )
+{
+  const Utils::MimeType mimeType = Utils::mimeTypeForFile( fileName );
+  const QString mimeName = mimeType.name();
+  return mimeName == QLatin1String( "text/x-qml" )
+         || fileName.endsWith( QLatin1String( ".qml" ), Qt::CaseInsensitive );
+}
+
+/*! \brief Read QML source text from an open editor or from disk.
+ *
+ * Open text documents are preferred so unsaved editor changes can be parsed.
+ * If the file is not open in Qt Creator, the content is read from disk.
+ * \param[in] fileName File path to read.
+ * \return Source text, or an empty string if the file cannot be read.
+ */
+QString readSource( const QString& fileName )
+{
+  TextEditor::TextDocument* textDocument = TextEditor::TextDocument::textDocumentForFilePath( Utils::FilePath::fromString( fileName ) );
+  if( textDocument != nullptr ) {
+    return textDocument->plainText();
+  }
+
+  QFile file( fileName );
+  if( file.open( QFile::ReadOnly | QFile::Text ) == false ) {
+    return {};
+  }
+
+  QTextStream stream( &file );
+  return stream.readAll();
+}
+
+} // namespace
+
+class SpellChecker::QmlSpellChecker::Internal::QmlDocumentParserPrivate
+{
+public:
+  ProjectExplorer::Project* activeProject = nullptr; /*!< Active project used for project-wide parsing. */
+  QString currentEditorFileName;                     /*!< Current editor file path. */
+  QmlParserSettings settings;                        /*!< User-visible QML parser settings. */
+  QmlParserOptionsPage optionsPage{&settings};       /*!< Options page backed by \a settings. */
+  QStringSet filesInStartupProject;                  /*!< QML files that belong to the startup project. */
+  QMutex futureMutex;                                /*!< Guards \a futureWatchers. */
+  QMap<QmlDocumentProcessor::WatcherPtr, QString> futureWatchers; /*!< Running parse jobs mapped to file paths. */
+  QHash<Core::IDocument*, QMetaObject::Connection> documentConnections; /*!< Content-change connections for open QML files. */
+  QHash<QString, QTimer*> reparseTimers;             /*!< Debounce timers for live document reparsing. */
+};
+
+QmlDocumentParser::QmlDocumentParser( QObject* parent )
+  : IDocumentParser( parent )
+  , d( new QmlDocumentParserPrivate() )
+{
+  d->settings.loadFromSettings( Core::ICore::settings() );
+
+  connect( &d->settings, &QmlParserSettings::settingsChanged, this, &QmlDocumentParser::settingsChanged );
+  connect( SpellCheckerCore::instance()->settings(), &SpellChecker::Internal::SpellCheckerCoreSettings::settingsChanged, this, &QmlDocumentParser::settingsChanged );
+
+  Core::Context context( QmlJSEditor::Constants::C_QMLJSEDITOR_ID );
+  Core::ActionContainer* qmlEditorContextMenu = Core::ActionManager::createMenu( QmlJSEditor::Constants::M_CONTEXT );
+  Core::ActionContainer* contextMenu = Core::ActionManager::createMenu( SpellChecker::Constants::CONTEXT_MENU_ID );
+  /* Add the shared Spell Check submenu to the QML editor context menu just like
+   * the C++ parser does for the C++ editor. */
+  qmlEditorContextMenu->addSeparator( context );
+  qmlEditorContextMenu->addMenu( contextMenu );
+
+  connect( Core::EditorManager::instance(), &Core::EditorManager::documentOpened, this, &QmlDocumentParser::watchDocument );
+  connect( Core::EditorManager::instance(), &Core::EditorManager::documentClosed, this, &QmlDocumentParser::unwatchDocument );
+  connect( Core::EditorManager::instance(), &Core::EditorManager::saved, this, [this]( Core::IDocument* document, Core::IDocument::SaveOption ) {
+    if( document != nullptr ) {
+      parseFile( document->filePath().path() );
+    }
+  } );
+  connect( qApp, &QCoreApplication::aboutToQuit, this, &QmlDocumentParser::aboutToQuit, Qt::DirectConnection );
+  connect( Core::ICore::instance(), &Core::ICore::saveSettingsRequested, this, [this] {
+    d->settings.saveToSettings( Core::ICore::settings() );
+  } );
+}
+
+QmlDocumentParser::~QmlDocumentParser()
+{
+  for( QTimer* timer: std::as_const( d->reparseTimers ) ) {
+    timer->stop();
+    timer->deleteLater();
+  }
+  delete d;
+}
+
+QString QmlDocumentParser::displayName()
+{
+  return tr( "QML Document Parser" );
+}
+
+Core::IOptionsPage* QmlDocumentParser::optionsPage()
+{
+  return &d->optionsPage;
+}
+
+void QmlDocumentParser::setCurrentEditor( const QString& editorFilePath )
+{
+  d->currentEditorFileName = editorFilePath;
+  parseFile( editorFilePath );
+}
+
+void QmlDocumentParser::setActiveProject( ProjectExplorer::Project* activeProject )
+{
+  d->activeProject = activeProject;
+  reparseProject();
+}
+
+void QmlDocumentParser::updateProjectFiles( QStringSet filesAdded, QStringSet filesRemoved )
+{
+  for( const QString& fileName: filesRemoved ) {
+    d->filesInStartupProject.remove( fileName );
+  }
+
+  const QStringSet qmlFiles = Utils::filtered( filesAdded, []( const QString& fileName ) {
+    return isQmlFile( fileName );
+  } );
+
+  d->filesInStartupProject.unite( qmlFiles );
+  for( const QString& fileName: qmlFiles ) {
+    parseFile( fileName );
+  }
+}
+
+void QmlDocumentParser::settingsChanged()
+{
+  reparseProject();
+  parseFile( d->currentEditorFileName );
+}
+
+void QmlDocumentParser::reparseProject()
+{
+  {
+    QMutexLocker locker( &d->futureMutex );
+    /* Settings or project changes make outstanding parse results stale. Cancel
+     * them before starting a new project parse. */
+    for( auto iter = d->futureWatchers.begin(); iter != d->futureWatchers.end(); ++iter ) {
+      iter.key()->cancel();
+    }
+    for( auto iter = d->futureWatchers.begin(); iter != d->futureWatchers.end(); ++iter ) {
+      iter.key()->disconnect( this );
+      iter.key()->waitForFinished();
+      delete iter.key();
+    }
+    d->futureWatchers.clear();
+  }
+
+  d->filesInStartupProject.clear();
+  if( d->activeProject == nullptr ) {
+    return;
+  }
+
+  const Utils::FilePaths projectFiles = d->activeProject->files( ProjectExplorer::Project::SourceFiles );
+  const auto fileList = Utils::transform<QStringSet>( projectFiles, &Utils::FilePath::path );
+  d->filesInStartupProject = Utils::filtered( fileList, []( const QString& fileName ) {
+    return isQmlFile( fileName );
+  } );
+
+  for( const QString& fileName: d->filesInStartupProject ) {
+    parseFile( fileName );
+  }
+}
+
+void QmlDocumentParser::parseFile( const QString& fileName )
+{
+  if( fileName.isEmpty() == true ) {
+    return;
+  }
+  if( isQmlFile( fileName ) == false ) {
+    return;
+  }
+  if( shouldParseDocument( fileName ) == false ) {
+    return;
+  }
+
+  {
+    QMutexLocker locker( &d->futureMutex );
+    QList<QmlDocumentProcessor::WatcherPtr> staleWatchers;
+    /* Prefer the latest source text for a file. If a previous parse is still
+     * running, cancel it so stale results cannot overwrite newer ones. */
+    for( auto iter = d->futureWatchers.begin(); iter != d->futureWatchers.end(); ++iter ) {
+      if( iter.value() == fileName ) {
+        staleWatchers.append( iter.key() );
+      }
+    }
+    for( QmlDocumentProcessor::WatcherPtr watcher: staleWatchers ) {
+      d->futureWatchers.remove( watcher );
+      watcher->disconnect( this );
+      watcher->cancel();
+      watcher->waitForFinished();
+      delete watcher;
+    }
+  }
+
+  const QString source = readSource( fileName );
+  if( source.isEmpty() == true ) {
+    emit spellcheckWordsParsed( fileName, WordList() );
+    return;
+  }
+
+  auto processor = new QmlDocumentProcessor( fileName, source, d->settings );
+  processor->moveToThread( qApp->thread() );
+
+  auto watcher = new QmlDocumentProcessor::Watcher();
+  watcher->moveToThread( qApp->thread() );
+  connect( watcher, &QmlDocumentProcessor::Watcher::finished, this, &QmlDocumentParser::futureFinished, Qt::QueuedConnection );
+  connect( watcher, &QmlDocumentProcessor::Watcher::finished, processor, &QmlDocumentProcessor::deleteLater );
+
+  {
+    QMutexLocker locker( &d->futureMutex );
+    d->futureWatchers.insert( watcher, fileName );
+  }
+
+  if( fileName == d->currentEditorFileName ) {
+    watcher->setFuture( Utils::asyncRun( QThread::HighPriority, &QmlDocumentProcessor::process, processor ) );
+  } else {
+    watcher->setFuture( Utils::asyncRun( QThreadPool::globalInstance(), QThread::LowPriority, &QmlDocumentProcessor::process, processor ) );
+  }
+}
+
+void QmlDocumentParser::scheduleParseFile( const QString& fileName )
+{
+  if( ( fileName.isEmpty() == true ) || ( isQmlFile( fileName ) == false ) ) {
+    return;
+  }
+
+  QTimer* timer = d->reparseTimers.value( fileName, nullptr );
+  if( timer == nullptr ) {
+    timer = new QTimer( this );
+    timer->setSingleShot( true );
+    timer->setInterval( 350 );
+    d->reparseTimers.insert( fileName, timer );
+    connect( timer, &QTimer::timeout, this, [this, fileName] {
+      parseFile( fileName );
+    } );
+  }
+  timer->start();
+}
+
+void QmlDocumentParser::watchDocument( Core::IDocument* document )
+{
+  if( document == nullptr ) {
+    return;
+  }
+  const QString fileName = document->filePath().path();
+  if( isQmlFile( fileName ) == false ) {
+    return;
+  }
+  if( d->documentConnections.contains( document ) == true ) {
+    return;
+  }
+
+  d->documentConnections.insert( document, connect( document, &Core::IDocument::contentsChanged, this, [this, document] {
+    scheduleParseFile( document->filePath().path() );
+  } ) );
+  scheduleParseFile( fileName );
+}
+
+void QmlDocumentParser::unwatchDocument( Core::IDocument* document )
+{
+  if( document == nullptr ) {
+    return;
+  }
+  const auto iter = d->documentConnections.find( document );
+  if( iter != d->documentConnections.end() ) {
+    disconnect( iter.value() );
+    d->documentConnections.erase( iter );
+  }
+}
+
+bool QmlDocumentParser::shouldParseDocument( const QString& fileName ) const
+{
+  SpellChecker::Internal::SpellCheckerCoreSettings* settings = SpellCheckerCore::instance()->settings();
+  if( ( settings->onlyParseCurrentFile == true )
+      && ( d->currentEditorFileName != fileName ) ) {
+    return false;
+  }
+
+  if( settings->checkExternalFiles == false ) {
+    return d->filesInStartupProject.contains( fileName );
+  }
+
+  return true;
+}
+
+void QmlDocumentParser::futureFinished()
+{
+  auto watcher = reinterpret_cast<QmlDocumentProcessor::WatcherPtr>( sender() );
+  if( watcher == nullptr ) {
+    return;
+  }
+  QString fileName;
+  {
+    QMutexLocker locker( &d->futureMutex );
+    const auto iter = d->futureWatchers.find( watcher );
+    if( iter != d->futureWatchers.end() ) {
+      fileName = iter.value();
+      d->futureWatchers.erase( iter );
+    }
+  }
+
+  if( watcher->isCanceled() == true ) {
+    watcher->deleteLater();
+    return;
+  }
+
+  const WordList words = watcher->result();
+  watcher->deleteLater();
+  if( fileName.isEmpty() == false ) {
+    emit spellcheckWordsParsed( fileName, words );
+  }
+}
+
+void QmlDocumentParser::aboutToQuit()
+{
+  setActiveProject( nullptr );
+  Core::EditorManager::instance()->disconnect( this );
+  SpellCheckerCore::instance()->disconnect( this );
+  this->disconnect( SpellCheckerCore::instance() );
+}

--- a/src/Parsers/QmlParser/qmldocumentparser.h
+++ b/src/Parsers/QmlParser/qmldocumentparser.h
@@ -1,0 +1,96 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#pragma once
+
+#include "../../idocumentparser.h"
+
+#include <projectexplorer/projectexplorer.h>
+
+namespace SpellChecker {
+namespace QmlSpellChecker {
+namespace Internal {
+
+class QmlDocumentParserPrivate;
+
+/*! \brief The QML document parser.
+ *
+ * This parser extracts spell-checkable words from QML comments and string
+ * literals. It follows the same parser contract as the C++ parser by reacting
+ * to current editor changes, project changes, settings changes and open
+ * document edits.
+ */
+class QmlDocumentParser
+  : public SpellChecker::IDocumentParser
+{
+  Q_OBJECT
+public:
+  explicit QmlDocumentParser( QObject* parent = nullptr );
+  ~QmlDocumentParser() override;
+
+  QString displayName() override;
+  Core::IOptionsPage* optionsPage() override;
+
+protected:
+  /*! \brief Update the current editor path and reparse it if it is a QML file.
+   * \param[in] editorFilePath Path of the current editor. */
+  void setCurrentEditor( const QString& editorFilePath ) override;
+  /*! \brief Update the active project and reparse project QML files.
+   * \param[in] activeProject Active Qt Creator project. */
+  void setActiveProject( ProjectExplorer::Project* activeProject ) override;
+  /*! \brief Parse newly added QML files and forget removed project files.
+   * \param[in] filesAdded Project files that were added.
+   * \param[in] filesRemoved Project files that were removed. */
+  void updateProjectFiles( QStringSet filesAdded, QStringSet filesRemoved ) override;
+
+private slots:
+  /*! \brief Reparse files after QML parser or core settings changed. */
+  void settingsChanged();
+  /*! \brief Handle completion of a background QML parse job. */
+  void futureFinished();
+  /*! \brief Disconnect and cancel work during Qt Creator shutdown. */
+  void aboutToQuit();
+
+private:
+  /*! \brief Cancel outstanding work and parse all QML files in the project. */
+  void reparseProject();
+  /*! \brief Parse one QML file if settings allow it.
+   * \param[in] fileName File to parse. */
+  void parseFile( const QString& fileName );
+  /*! \brief Debounce reparsing for edited open QML documents.
+   * \param[in] fileName File to schedule for parsing. */
+  void scheduleParseFile( const QString& fileName );
+  /*! \brief Start watching an open QML document for content changes.
+   * \param[in] document Document to watch. */
+  void watchDocument( Core::IDocument* document );
+  /*! \brief Stop watching a document that was closed.
+   * \param[in] document Document to unwatch. */
+  void unwatchDocument( Core::IDocument* document );
+  /*! \brief Query whether the file should currently be parsed.
+   * \param[in] fileName File to check.
+   * \return true when the QML parser should parse the file. */
+  bool shouldParseDocument( const QString& fileName ) const;
+
+  QmlDocumentParserPrivate* const d;
+};
+
+} // namespace Internal
+} // namespace QmlSpellChecker
+} // namespace SpellChecker

--- a/src/Parsers/QmlParser/qmldocumentprocessor.cpp
+++ b/src/Parsers/QmlParser/qmldocumentprocessor.cpp
@@ -1,0 +1,415 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include "qmldocumentprocessor.h"
+
+#include <QRegularExpression>
+
+using namespace SpellChecker;
+using namespace SpellChecker::QmlSpellChecker::Internal;
+
+namespace {
+
+/*! \brief Line and column while scanning source text.
+ *
+ * Both values are one-based to match Qt Creator editor line and column
+ * positions used elsewhere by the plugin.
+ */
+struct SourcePosition
+{
+  int line = 1;
+  int column = 1;
+};
+
+/*! \brief QML text range that should be tokenized into words. */
+struct Token
+{
+  /*! \brief Kind of source text that produced the token. */
+  enum class Type {
+    Comment, /*!< QML line or block comment. */
+    Literal  /*!< QML string or template literal. */
+  };
+
+  Type type;    /*!< Token type. */
+  QString text; /*!< Token source text. */
+  int start = 0;/*!< Start offset in the original source. */
+  int end = 0;  /*!< End offset in the original source. */
+};
+
+/*! \brief Advance a one-based source position by one character.
+ * \param[in] c Character consumed.
+ * \param[inout] position Position to update. */
+void advancePosition( const QChar c, SourcePosition& position )
+{
+  if( c == QLatin1Char( '\n' ) ) {
+    ++position.line;
+    position.column = 1;
+  } else {
+    ++position.column;
+  }
+}
+
+/*! \brief Query whether a quote at \a index is escaped.
+ * \param[in] source Source text.
+ * \param[in] index Index of the quote to inspect.
+ * \return true when the quote is preceded by an odd number of backslashes. */
+bool isEscaped( const QString& source, int index )
+{
+  int backslashCount = 0;
+  for( int i = index - 1; ( i >= 0 ) && ( source.at( i ) == QLatin1Char( '\\' ) ); --i ) {
+    ++backslashCount;
+  }
+  return ( backslashCount % 2 ) == 1;
+}
+
+/*! \brief Query whether a character can be part of a raw word candidate.
+ *
+ * URL and email punctuation is included here so those strings can be extracted
+ * as one candidate and then filtered out by dedicated false-positive filters.
+ * \param[in] c Character to classify.
+ * \return true when the scanner should keep reading the current candidate.
+ */
+bool isWordCharacter( const QChar c )
+{
+  return c.isLetterOrNumber()
+         || ( c == QLatin1Char( '_' ) )
+         || ( c == QLatin1Char( '.' ) )
+         || ( c == QLatin1Char( '@' ) )
+         || ( c == QLatin1Char( '\'' ) )
+         || ( c == QLatin1Char( ':' ) )
+         || ( c == QLatin1Char( '/' ) )
+         || ( c == QLatin1Char( '?' ) )
+         || ( c == QLatin1Char( '=' ) )
+         || ( c == QLatin1Char( '#' ) )
+         || ( c == QLatin1Char( '%' ) )
+         || ( c == QLatin1Char( '-' ) );
+}
+
+/*! \brief Query whether a character should be trimmed from word edges.
+ * \param[in] c Character to inspect.
+ * \return true for punctuation that should not be spell checked as part of a word. */
+bool isEdgePunctuation( const QChar c )
+{
+  return ( c.isLetterOrNumber() == false ) && ( c != QLatin1Char( '\'' ) );
+}
+
+/*! \brief Query whether a word candidate is a number or color.
+ * \param[in] word Candidate text.
+ * \return true if the candidate should be ignored as numeric/color data. */
+bool isNumberOrColor( const QString& word )
+{
+  static const QRegularExpression doubleRe( QStringLiteral( "\\A\\d+(\\.\\d+)?\\z" ) );
+  static const QRegularExpression hexRe( QStringLiteral( "\\A0x[0-9A-Fa-f]+\\z" ) );
+  static const QRegularExpression colorRe( QStringLiteral( "\\A#?([0-9A-Fa-f]{2}){3,4}\\z" ) );
+  return doubleRe.match( word ).hasMatch()
+         || hexRe.match( word ).hasMatch()
+         || colorRe.match( word ).hasMatch();
+}
+
+/*! \brief Query whether a word candidate is an email address.
+ * \param[in] word Candidate text.
+ * \return true if the candidate looks like an email address. */
+bool isEmailAddress( const QString& word )
+{
+  static const QRegularExpression emailRe( QStringLiteral( "\\A[\\w\\-\\.]+@((?:[\\w]+\\.)+)[a-zA-Z]{2,}\\z" ) );
+  return emailRe.match( word ).hasMatch();
+}
+
+/*! \brief Query whether a word candidate is a website address.
+ * \param[in] word Candidate text.
+ * \return true if the candidate looks like a website address. */
+bool isWebsite( const QString& word )
+{
+  static const QRegularExpression websiteRe( QStringLiteral( "\\A((http(s)?):\\/\\/)?(\\w+\\.){1,10}[0-9A-Za-z./?=#%\\-]+\\z" ) );
+  return websiteRe.match( word ).hasMatch();
+}
+
+/*! \brief Split camelCase words using the same rough rule as the C++ parser.
+ * \param[in] word Word candidate to split.
+ * \return Split words, or the original word when no camelCase boundary is found. */
+QStringList splitCamelCase( const QString& word )
+{
+  static const QRegularExpression camelCaseContainsRe( QStringLiteral( "[a-z]{1,}[A-Z]{1,}[a-z]{1,}" ) );
+  static const QRegularExpression camelCaseIndexRe( QStringLiteral( "[a-z][A-Z]" ) );
+  if( word.contains( camelCaseContainsRe ) == false ) {
+    return { word };
+  }
+
+  QStringList splitWords;
+  QList<int> indexes;
+  indexes << 0;
+  int lastIdx = 0;
+  while( true ) {
+    const int currentIdx = word.indexOf( camelCaseIndexRe, lastIdx );
+    if( currentIdx == -1 ) {
+      indexes << word.length();
+      break;
+    }
+    lastIdx = currentIdx + 1;
+    indexes << lastIdx;
+  }
+
+  for( int idx = 0; idx < indexes.count() - 1; ++idx ) {
+    splitWords << word.mid( indexes.at( idx ), indexes.at( idx + 1 ) - indexes.at( idx ) );
+  }
+  return splitWords;
+}
+
+/*! \brief Convert string split results back to positioned Word objects.
+ * \param[in] stringList Split word texts.
+ * \param[in] word Original word that was split.
+ * \return Word objects with adjusted line, column and source offsets. */
+WordList wordsFromSplitString( const QStringList& stringList, const Word& word )
+{
+  WordList wordList;
+  int currentPos = 0;
+  for( const QString& text: stringList ) {
+    Word newWord;
+    newWord.text = text;
+    newWord.fileName = word.fileName;
+    currentPos = word.text.indexOf( newWord.text, currentPos );
+    newWord.columnNumber = word.columnNumber + currentPos;
+    newWord.lineNumber = word.lineNumber;
+    newWord.length = newWord.text.length();
+    newWord.start = word.start + currentPos;
+    newWord.end = newWord.start + newWord.length;
+    newWord.charAfter = word.charAfter;
+    newWord.inComment = word.inComment;
+    currentPos += newWord.length;
+    wordList.append( newWord );
+  }
+  return wordList;
+}
+
+/*! \brief Apply QML parser filters and append a word if it should be checked.
+ *
+ * This handles common false positives and recursively splits words on numbers,
+ * underscores, dots and camelCase boundaries.
+ * \param[in] word Candidate word.
+ * \param[in] settings Parser settings.
+ * \param[inout] words Destination list for accepted words. */
+void appendWordWithSplits( const Word& word, const QmlParserSettings& settings, WordList& words )
+{
+  const QString currentWord = word.text;
+  const QString currentWordCaps = currentWord.toUpper();
+
+  if( isNumberOrColor( currentWord ) ) {
+    return;
+  }
+  if( ( settings.removeEmailAddresses == true ) && isEmailAddress( currentWord ) ) {
+    return;
+  }
+  if( ( settings.removeWebsites == true ) && isWebsite( currentWord ) ) {
+    return;
+  }
+  if( ( settings.checkAllCapsWords == false ) && ( currentWord == currentWordCaps ) ) {
+    return;
+  }
+
+  static const QRegularExpression splitRe( QStringLiteral( "[0-9_\\.]+" ) );
+  const QStringList pieces = currentWord.split( splitRe, Qt::SkipEmptyParts );
+  if( pieces.count() > 1 ) {
+    WordList splitWords = wordsFromSplitString( pieces, word );
+    for( const Word& splitWord: splitWords ) {
+      appendWordWithSplits( splitWord, settings, words );
+    }
+    return;
+  }
+
+  const QStringList camelCaseWords = splitCamelCase( currentWord );
+  if( camelCaseWords.count() > 1 ) {
+    WordList splitWords = wordsFromSplitString( camelCaseWords, word );
+    for( const Word& splitWord: splitWords ) {
+      appendWordWithSplits( splitWord, settings, words );
+    }
+    return;
+  }
+
+  words.append( word );
+}
+
+/*! \brief Extract positioned words from one token.
+ * \param[in] fileName File name to assign to each word.
+ * \param[in] source Full source text.
+ * \param[in] token Token to split into words.
+ * \param[in] settings Parser settings.
+ * \param[inout] words Destination list for accepted words. */
+void extractWordsFromToken( const QString& fileName, const QString& source, const Token& token, const QmlParserSettings& settings, WordList& words )
+{
+  SourcePosition position;
+  for( int idx = 0; idx < token.start; ++idx ) {
+    advancePosition( source.at( idx ), position );
+  }
+
+  int wordStart = -1;
+  SourcePosition wordPosition = position;
+  for( int idx = token.start; idx <= token.end; ++idx ) {
+    const bool atEnd = idx >= token.end;
+    const QChar c = atEnd ? QLatin1Char( ' ' ) : source.at( idx );
+    const bool wordCharacter = ( atEnd == false ) && isWordCharacter( c );
+
+    if( wordCharacter && ( wordStart < 0 ) ) {
+      wordStart = idx;
+      wordPosition = position;
+    }
+
+    if( ( wordStart >= 0 ) && ( wordCharacter == false ) ) {
+      int normalizedStart = wordStart;
+      int normalizedEnd = idx;
+      while( ( normalizedStart < normalizedEnd ) && isEdgePunctuation( source.at( normalizedStart ) ) ) {
+        ++normalizedStart;
+      }
+      while( ( normalizedEnd > normalizedStart ) && isEdgePunctuation( source.at( normalizedEnd - 1 ) ) ) {
+        --normalizedEnd;
+      }
+      if( normalizedStart >= normalizedEnd ) {
+        wordStart = -1;
+        if( atEnd == false ) {
+          advancePosition( c, position );
+        }
+        continue;
+      }
+
+      Word word;
+      word.fileName = fileName;
+      word.text = source.mid( normalizedStart, normalizedEnd - normalizedStart );
+      word.start = normalizedStart;
+      word.end = normalizedEnd;
+      word.length = normalizedEnd - normalizedStart;
+      word.charAfter = atEnd ? QLatin1Char( ' ' ) : c;
+      word.inComment = ( token.type == Token::Type::Comment );
+      word.lineNumber = wordPosition.line;
+      word.columnNumber = wordPosition.column + ( normalizedStart - wordStart );
+      appendWordWithSplits( word, settings, words );
+      wordStart = -1;
+    }
+
+    if( atEnd == false ) {
+      advancePosition( c, position );
+    }
+  }
+}
+
+/*! \brief Scan QML source for comments and string literals.
+ * \param[in] source Full QML source text.
+ * \param[in] settings Parser settings controlling which token types are emitted.
+ * \return Token ranges to split into words. */
+QVector<Token> scanTokens( const QString& source, const QmlParserSettings& settings )
+{
+  QVector<Token> tokens;
+  const int length = source.length();
+
+  for( int i = 0; i < length; ) {
+    const QChar c = source.at( i );
+    const QChar next = ( i + 1 < length ) ? source.at( i + 1 ) : QLatin1Char( '\0' );
+
+    if( ( settings.whatToCheck.testFlag( QmlParserSettings::CheckComments ) == true )
+        && ( c == QLatin1Char( '/' ) )
+        && ( next == QLatin1Char( '/' ) ) ) {
+      const int start = i + 2;
+      i += 2;
+      while( ( i < length ) && ( source.at( i ) != QLatin1Char( '\n' ) ) ) {
+        ++i;
+      }
+      tokens.append( Token{ Token::Type::Comment, source.mid( start, i - start ), start, i } );
+      continue;
+    }
+
+    if( ( settings.whatToCheck.testFlag( QmlParserSettings::CheckComments ) == true )
+        && ( c == QLatin1Char( '/' ) )
+        && ( next == QLatin1Char( '*' ) ) ) {
+      const int start = i + 2;
+      i += 2;
+      bool closed = false;
+      while( i + 1 < length ) {
+        if( ( source.at( i ) == QLatin1Char( '*' ) ) && ( source.at( i + 1 ) == QLatin1Char( '/' ) ) ) {
+          const int end = i;
+          i += 2;
+          tokens.append( Token{ Token::Type::Comment, source.mid( start, end - start ), start, end } );
+          closed = true;
+          break;
+        }
+        ++i;
+      }
+      if( closed == false ) {
+        tokens.append( Token{ Token::Type::Comment, source.mid( start ), start, length } );
+        i = length;
+      }
+      continue;
+    }
+
+    if( ( settings.whatToCheck.testFlag( QmlParserSettings::CheckStringLiterals ) == true )
+        && ( ( c == QLatin1Char( '"' ) ) || ( c == QLatin1Char( '\'' ) ) || ( c == QLatin1Char( '`' ) ) ) ) {
+      const QChar quote = c;
+      const int start = i + 1;
+      ++i;
+      bool closed = false;
+      while( i < length ) {
+        if( ( source.at( i ) == quote ) && ( isEscaped( source, i ) == false ) ) {
+          const int end = i;
+          ++i;
+          tokens.append( Token{ Token::Type::Literal, source.mid( start, end - start ), start, end } );
+          closed = true;
+          break;
+        }
+        ++i;
+      }
+      if( closed == false ) {
+        tokens.append( Token{ Token::Type::Literal, source.mid( start ), start, length } );
+      }
+      continue;
+    }
+
+    ++i;
+  }
+
+  return tokens;
+}
+
+} // namespace
+
+QmlDocumentProcessor::QmlDocumentProcessor( const QString& fileName, const QString& source, const QmlParserSettings& settings )
+  : QObject( nullptr )
+  , m_fileName( fileName )
+  , m_source( source )
+  , m_settings( settings )
+{}
+
+QmlDocumentProcessor::~QmlDocumentProcessor() = default;
+
+void QmlDocumentProcessor::process( QmlDocumentProcessor::Promise& promise )
+{
+  if( promise.isCanceled() == true ) {
+    promise.future().cancel();
+    return;
+  }
+
+  promise.addResult( parseSource( m_fileName, m_source, m_settings ) );
+}
+
+WordList QmlDocumentProcessor::parseSource( const QString& fileName, const QString& source, const QmlParserSettings& settings )
+{
+  WordList words;
+  const QVector<Token> tokens = scanTokens( source, settings );
+  for( const Token& token: tokens ) {
+    extractWordsFromToken( fileName, source, token, settings, words );
+  }
+  return words;
+}

--- a/src/Parsers/QmlParser/qmldocumentprocessor.h
+++ b/src/Parsers/QmlParser/qmldocumentprocessor.h
@@ -1,0 +1,76 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#pragma once
+
+#include "../../Word.h"
+#include "qmlparsersettings.h"
+
+#include <QFuture>
+#include <QObject>
+
+namespace SpellChecker {
+namespace QmlSpellChecker {
+namespace Internal {
+
+/*! \brief Background processor for a QML document.
+ *
+ * The processor owns a snapshot of QML source text and extracts words from
+ * comments and string literals. It is intentionally independent from Qt Creator
+ * editor objects so the scanner can be unit tested without starting Qt Creator.
+ */
+class QmlDocumentProcessor
+  : public QObject
+{
+  Q_OBJECT
+  QmlDocumentProcessor( const QmlDocumentProcessor& ) = delete;
+  QmlDocumentProcessor& operator=( const QmlDocumentProcessor& ) = delete;
+public:
+  using Watcher = QFutureWatcher<WordList>;
+  using WatcherPtr = Watcher *;
+  using Promise = QPromise<WordList>;
+
+  /*! \brief Constructor.
+   * \param[in] fileName File name associated with the source snapshot.
+   * \param[in] source Source text to parse.
+   * \param[in] settings Parser settings to apply. */
+  QmlDocumentProcessor( const QString& fileName, const QString& source, const QmlParserSettings& settings );
+  ~QmlDocumentProcessor() override;
+
+  /*! \brief Process function run by QtConcurrent.
+   * \param[inout] promise Future promise used to report the extracted words. */
+  void process( Promise& promise );
+
+  /*! \brief Parse QML source text into spell-checkable words.
+   * \param[in] fileName File name to store on each returned word.
+   * \param[in] source Source text to scan.
+   * \param[in] settings Parser settings to apply.
+   * \return Words extracted from comments and string literals. */
+  static WordList parseSource( const QString& fileName, const QString& source, const QmlParserSettings& settings );
+
+private:
+  QString m_fileName;
+  QString m_source;
+  QmlParserSettings m_settings;
+};
+
+} // namespace Internal
+} // namespace QmlSpellChecker
+} // namespace SpellChecker

--- a/src/Parsers/QmlParser/qmlparserconstants.h
+++ b/src/Parsers/QmlParser/qmlparserconstants.h
@@ -1,0 +1,37 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#pragma once
+
+namespace SpellChecker {
+namespace Parsers {
+namespace QmlParser {
+namespace Constants {
+
+const char QML_PARSER_GROUP[]       = "QmlParser";             /*!< Settings group for QML parser options. */
+const char WHAT_TO_CHECK[]          = "WhatToCheck";           /*!< Settings key for checked token types. */
+const char REMOVE_EMAIL_ADDRESSES[] = "removeEmailAddresses";  /*!< Settings key for email filtering. */
+const char CHECK_CAPS[]             = "checkAllCapsWords";     /*!< Settings key for all-caps word handling. */
+const char REMOVE_WEBSITES[]        = "removeWebsites";        /*!< Settings key for website filtering. */
+
+} // namespace Constants
+} // namespace QmlParser
+} // namespace Parsers
+} // namespace SpellChecker

--- a/src/Parsers/QmlParser/qmlparseroptionspage.cpp
+++ b/src/Parsers/QmlParser/qmlparseroptionspage.cpp
@@ -1,0 +1,50 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include "qmlparseroptionspage.h"
+
+using namespace SpellChecker::QmlSpellChecker::Internal;
+
+QmlParserOptionsPage::QmlParserOptionsPage( QmlParserSettings* settings )
+  : Core::IOptionsPage()
+  , m_settings( settings )
+{
+  setId( "SpellChecker::QmlDocumentParserSettings" );
+  setDisplayName( QmlParserOptionsWidget::tr( "QML Parser" ) );
+  setCategory( "SpellChecker" );
+  registerCategory( "SpellChecker",
+                    QmlParserOptionsWidget::tr( "Spell Checker" ),
+                    ":/spellcheckerplugin/images/optionspageicon_solid.png" );
+  setWidgetCreator( [this]() -> Core::IOptionsPageWidget * {
+    if( m_widget == nullptr ) {
+      m_widget = new QmlParserOptionsWidget( m_settings );
+      m_widget->setOnApply( [this]() {
+        *m_settings = m_widget->settings();
+      } );
+      m_widget->setDirtyChecker( [this]() {
+        return *m_settings != m_widget->settings();
+      } );
+    }
+    return m_widget;
+  } );
+  setFixedKeywords( { QLatin1String( "SpellChecker" ), QLatin1String( "QML" ) } );
+}
+
+QmlParserOptionsPage::~QmlParserOptionsPage() = default;

--- a/src/Parsers/QmlParser/qmlparseroptionspage.h
+++ b/src/Parsers/QmlParser/qmlparseroptionspage.h
@@ -1,0 +1,53 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#pragma once
+
+#include "qmlparseroptionswidget.h"
+#include "qmlparsersettings.h"
+
+#include <coreplugin/dialogs/ioptionspage.h>
+
+namespace SpellChecker {
+namespace QmlSpellChecker {
+namespace Internal {
+
+/*! \brief Exposes QML spell-checking settings in Qt Creator's options dialog.
+ *
+ * This class connects the persistent QML parser settings to the options
+ * widget managed by Qt Creator.
+ */
+class QmlParserOptionsPage
+  : public Core::IOptionsPage
+{
+public:
+  /*! \brief Constructor.
+   * \param[in] settings Settings object edited by this page. */
+  explicit QmlParserOptionsPage( QmlParserSettings* settings );
+  ~QmlParserOptionsPage() override;
+
+private:
+  QmlParserSettings* m_settings;             /*!< Settings object edited by the page. */
+  QmlParserOptionsWidget* m_widget = nullptr;/*!< Lazily-created page widget. */
+};
+
+} // namespace Internal
+} // namespace QmlSpellChecker
+} // namespace SpellChecker

--- a/src/Parsers/QmlParser/qmlparseroptionswidget.cpp
+++ b/src/Parsers/QmlParser/qmlparseroptionswidget.cpp
@@ -1,0 +1,90 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include "qmlparseroptionswidget.h"
+
+#include <utils/qtcsettings.h>
+
+#include <QCheckBox>
+#include <QVBoxLayout>
+
+using namespace SpellChecker::QmlSpellChecker::Internal;
+
+QmlParserOptionsWidget::QmlParserOptionsWidget( QmlParserSettings* settings )
+{
+  auto layout = new QVBoxLayout( this );
+
+  m_checkComments = new QCheckBox( tr( "Check comments" ), this );
+  m_checkStringLiterals = new QCheckBox( tr( "Check string literals" ), this );
+  m_ignoreAllCaps = new QCheckBox( tr( "Ignore all-caps words" ), this );
+  m_removeEmailAddresses = new QCheckBox( tr( "Ignore email addresses" ), this );
+  m_removeWebsites = new QCheckBox( tr( "Ignore website addresses" ), this );
+
+  layout->addWidget( m_checkComments );
+  layout->addWidget( m_checkStringLiterals );
+  layout->addWidget( m_ignoreAllCaps );
+  layout->addWidget( m_removeEmailAddresses );
+  layout->addWidget( m_removeWebsites );
+  layout->addStretch( 1 );
+
+  updateWithSettings( settings );
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+  connect( m_checkComments, &QCheckBox::checkStateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_checkStringLiterals, &QCheckBox::checkStateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_ignoreAllCaps, &QCheckBox::checkStateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_removeEmailAddresses, &QCheckBox::checkStateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_removeWebsites, &QCheckBox::checkStateChanged, this, [](){ Utils::markSettingsDirty(); } );
+#else
+  connect( m_checkComments, &QCheckBox::stateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_checkStringLiterals, &QCheckBox::stateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_ignoreAllCaps, &QCheckBox::stateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_removeEmailAddresses, &QCheckBox::stateChanged, this, [](){ Utils::markSettingsDirty(); } );
+  connect( m_removeWebsites, &QCheckBox::stateChanged, this, [](){ Utils::markSettingsDirty(); } );
+#endif
+}
+
+QmlParserOptionsWidget::~QmlParserOptionsWidget() = default;
+
+const QmlParserSettings& QmlParserOptionsWidget::settings()
+{
+  QmlParserSettings::WhatToCheckOptions whatToCheck = QmlParserSettings::Tokens_NONE;
+  if( m_checkComments->isChecked() == true ) {
+    whatToCheck |= QmlParserSettings::CheckComments;
+  }
+  if( m_checkStringLiterals->isChecked() == true ) {
+    whatToCheck |= QmlParserSettings::CheckStringLiterals;
+  }
+
+  m_settings.whatToCheck = whatToCheck;
+  m_settings.checkAllCapsWords = !m_ignoreAllCaps->isChecked();
+  m_settings.removeEmailAddresses = m_removeEmailAddresses->isChecked();
+  m_settings.removeWebsites = m_removeWebsites->isChecked();
+  return m_settings;
+}
+
+void QmlParserOptionsWidget::updateWithSettings( const QmlParserSettings* settings )
+{
+  m_checkComments->setChecked( settings->whatToCheck.testFlag( QmlParserSettings::CheckComments ) );
+  m_checkStringLiterals->setChecked( settings->whatToCheck.testFlag( QmlParserSettings::CheckStringLiterals ) );
+  m_ignoreAllCaps->setChecked( !settings->checkAllCapsWords );
+  m_removeEmailAddresses->setChecked( settings->removeEmailAddresses );
+  m_removeWebsites->setChecked( settings->removeWebsites );
+}

--- a/src/Parsers/QmlParser/qmlparseroptionswidget.h
+++ b/src/Parsers/QmlParser/qmlparseroptionswidget.h
@@ -1,0 +1,69 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#pragma once
+
+#include "qmlparsersettings.h"
+
+#include <coreplugin/dialogs/ioptionspage.h>
+
+QT_BEGIN_NAMESPACE
+class QCheckBox;
+QT_END_NAMESPACE
+
+namespace SpellChecker {
+namespace QmlSpellChecker {
+namespace Internal {
+
+/*! \brief Provides controls for configuring QML spell checking.
+ *
+ * This class edits which QML text is checked and which common false-positive
+ * patterns are ignored.
+ */
+class QmlParserOptionsWidget
+  : public Core::IOptionsPageWidget
+{
+  Q_OBJECT
+public:
+  /*! \brief Constructor.
+   * \param[in] settings Initial settings used to populate the controls. */
+  explicit QmlParserOptionsWidget( QmlParserSettings* settings );
+  ~QmlParserOptionsWidget() override;
+
+  /*! \brief Collect current widget state into a settings object.
+   * \return Settings represented by the current UI state. */
+  const QmlParserSettings& settings();
+
+private:
+  /*! \brief Populate controls from settings.
+   * \param[in] settings Settings to show. */
+  void updateWithSettings( const QmlParserSettings* settings );
+
+  QmlParserSettings m_settings;      /*!< Cached settings returned by settings(). */
+  QCheckBox* m_checkComments;        /*!< Toggle for checking comments. */
+  QCheckBox* m_checkStringLiterals;  /*!< Toggle for checking string literals. */
+  QCheckBox* m_ignoreAllCaps;        /*!< Toggle for removing all-caps words. */
+  QCheckBox* m_removeEmailAddresses; /*!< Toggle for removing email addresses. */
+  QCheckBox* m_removeWebsites;       /*!< Toggle for removing website addresses. */
+};
+
+} // namespace Internal
+} // namespace QmlSpellChecker
+} // namespace SpellChecker

--- a/src/Parsers/QmlParser/qmlparsersettings.cpp
+++ b/src/Parsers/QmlParser/qmlparsersettings.cpp
@@ -1,0 +1,109 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include "qmlparsersettings.h"
+
+#include "../../spellcheckerconstants.h"
+#include "qmlparserconstants.h"
+
+using namespace SpellChecker::QmlSpellChecker::Internal;
+
+QmlParserSettings::QmlParserSettings()
+  : QObject( nullptr )
+{
+  setDefaults();
+}
+
+QmlParserSettings::QmlParserSettings( const QmlParserSettings& settings )
+  : QObject( nullptr )
+{
+  whatToCheck          = settings.whatToCheck;
+  removeEmailAddresses = settings.removeEmailAddresses;
+  checkAllCapsWords    = settings.checkAllCapsWords;
+  removeWebsites       = settings.removeWebsites;
+}
+
+QmlParserSettings::~QmlParserSettings() = default;
+
+void QmlParserSettings::loadFromSettings( Utils::QtcSettings* settings )
+{
+  setDefaults();
+
+  settings->beginGroup( SpellChecker::Constants::CORE_SETTINGS_GROUP );
+  settings->beginGroup( SpellChecker::Constants::CORE_PARSERS_GROUP );
+  settings->beginGroup( SpellChecker::Parsers::QmlParser::Constants::QML_PARSER_GROUP );
+
+  whatToCheck          = static_cast<WhatToCheckOptions>( settings->value( SpellChecker::Parsers::QmlParser::Constants::WHAT_TO_CHECK, int( whatToCheck ) ).toInt() );
+  removeEmailAddresses = settings->value( SpellChecker::Parsers::QmlParser::Constants::REMOVE_EMAIL_ADDRESSES, removeEmailAddresses ).toBool();
+  checkAllCapsWords    = settings->value( SpellChecker::Parsers::QmlParser::Constants::CHECK_CAPS, checkAllCapsWords ).toBool();
+  removeWebsites       = settings->value( SpellChecker::Parsers::QmlParser::Constants::REMOVE_WEBSITES, removeWebsites ).toBool();
+
+  settings->endGroup();
+  settings->endGroup();
+  settings->endGroup();
+  settings->sync();
+}
+
+void QmlParserSettings::saveToSettings( Utils::QtcSettings* settings ) const
+{
+  settings->beginGroup( SpellChecker::Constants::CORE_SETTINGS_GROUP );
+  settings->beginGroup( SpellChecker::Constants::CORE_PARSERS_GROUP );
+  settings->beginGroup( SpellChecker::Parsers::QmlParser::Constants::QML_PARSER_GROUP );
+
+  settings->setValue( SpellChecker::Parsers::QmlParser::Constants::WHAT_TO_CHECK, int( whatToCheck ) );
+  settings->setValue( SpellChecker::Parsers::QmlParser::Constants::REMOVE_EMAIL_ADDRESSES, removeEmailAddresses );
+  settings->setValue( SpellChecker::Parsers::QmlParser::Constants::CHECK_CAPS, checkAllCapsWords );
+  settings->setValue( SpellChecker::Parsers::QmlParser::Constants::REMOVE_WEBSITES, removeWebsites );
+
+  settings->endGroup();
+  settings->endGroup();
+  settings->endGroup();
+  settings->sync();
+}
+
+void QmlParserSettings::setDefaults()
+{
+  whatToCheck          = CheckBoth;
+  removeEmailAddresses = true;
+  checkAllCapsWords    = false;
+  removeWebsites       = true;
+}
+
+QmlParserSettings& QmlParserSettings::operator=( const QmlParserSettings& other )
+{
+  const bool settingsSame = ( operator==( other ) );
+  if( settingsSame == false ) {
+    whatToCheck          = other.whatToCheck;
+    removeEmailAddresses = other.removeEmailAddresses;
+    checkAllCapsWords    = other.checkAllCapsWords;
+    removeWebsites       = other.removeWebsites;
+    emit settingsChanged();
+  }
+
+  return *this;
+}
+
+bool QmlParserSettings::operator==( const QmlParserSettings& other ) const
+{
+  return ( whatToCheck == other.whatToCheck )
+         && ( removeEmailAddresses == other.removeEmailAddresses )
+         && ( checkAllCapsWords == other.checkAllCapsWords )
+         && ( removeWebsites == other.removeWebsites );
+}

--- a/src/Parsers/QmlParser/qmlparsersettings.h
+++ b/src/Parsers/QmlParser/qmlparsersettings.h
@@ -1,0 +1,84 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#pragma once
+
+#include <utils/qtcsettings.h>
+
+#include <QObject>
+
+namespace SpellChecker {
+namespace QmlSpellChecker {
+namespace Internal {
+
+/*! \brief Settings for the QML parser.
+ *
+ * These settings control what QML token types are checked and which common
+ * false positives are removed before words are passed to the spell checker.
+ */
+class QmlParserSettings
+  : public QObject
+{
+  Q_OBJECT
+  Q_ENUMS( WhatToCheck )
+  Q_FLAGS( WhatToCheckOptions )
+public:
+  QmlParserSettings();
+  QmlParserSettings( const QmlParserSettings& settings );
+  ~QmlParserSettings() override;
+
+  /*! \brief QML token types that should be spell checked. */
+  enum WhatToCheck {
+    Tokens_NONE         = 0,                              /*!< Nothing should be checked. */
+    CheckComments       = 1 << 0,                         /*!< Check QML line and block comments. */
+    CheckStringLiterals = 1 << 1,                         /*!< Check QML string and template literals. */
+    CheckBoth           = CheckComments | CheckStringLiterals /*!< Check comments and literals. */
+  };
+  Q_DECLARE_FLAGS( WhatToCheckOptions, WhatToCheck )
+
+  WhatToCheckOptions whatToCheck; /*!< Token types to parse. */
+  bool removeEmailAddresses;      /*!< Remove email addresses before spell checking. */
+  bool checkAllCapsWords;         /*!< Keep all-caps words when true. */
+  bool removeWebsites;            /*!< Remove website addresses before spell checking. */
+
+  /*! \brief Load settings from Qt Creator settings.
+   * \param[in] settings Qt Creator settings object. */
+  void loadFromSettings( Utils::QtcSettings* settings );
+  /*! \brief Save settings to Qt Creator settings.
+   * \param[in] settings Qt Creator settings object. */
+  void saveToSettings( Utils::QtcSettings* settings ) const;
+
+  QmlParserSettings& operator=( const QmlParserSettings& other );
+  bool operator==( const QmlParserSettings& other ) const;
+
+signals:
+  /*! \brief Emitted when assignment changes one or more settings. */
+  void settingsChanged();
+
+private:
+  /*! \brief Reset all values to defaults. */
+  void setDefaults();
+};
+
+} // namespace Internal
+} // namespace QmlSpellChecker
+} // namespace SpellChecker
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( SpellChecker::QmlSpellChecker::Internal::QmlParserSettings::WhatToCheckOptions )

--- a/src/spellcheckerplugin.cpp
+++ b/src/spellcheckerplugin.cpp
@@ -31,6 +31,7 @@
 /* Parsers */
 #include "Parsers/CppParser/cppdocumentparser.h"
 #include "Parsers/CppParser/cppparsersettings.h"
+#include "Parsers/QmlParser/qmldocumentparser.h"
 
 #include <coreplugin/actionmanager/actioncontainer.h>
 #include <coreplugin/actionmanager/actionmanager.h>
@@ -62,6 +63,7 @@ public:
   std::unique_ptr<NavigationWidgetFactory> navFactory;
   std::unique_ptr<SpellChecker::ISpellChecker> spellChecker;
   std::unique_ptr<SpellChecker::IDocumentParser> cppParser;
+  std::unique_ptr<SpellChecker::IDocumentParser> qmlParser;
   std::unique_ptr<SpellCheckCppQuickFixFactory>  quickFixFactory;
 };
 
@@ -182,8 +184,11 @@ Utils::Result<> SpellCheckerPlugin::initialize(const QStringList& arguments)
 
   /* Cpp Document Parser */
   d->cppParser = std::make_unique<SpellChecker::CppSpellChecker::Internal::CppDocumentParser>();
-
   d->spellCheckerCore->addDocumentParser( d->cppParser.get() );
+
+  /* QML Document Parser */
+  d->qmlParser = std::make_unique<SpellChecker::QmlSpellChecker::Internal::QmlDocumentParser>();
+  d->spellCheckerCore->addDocumentParser( d->qmlParser.get() );
 
   /* Quick fix provider */
   d->quickFixFactory = std::make_unique<SpellCheckCppQuickFixFactory>();

--- a/tests/qmlparser/tst_qmldocumentprocessor.cpp
+++ b/tests/qmlparser/tst_qmldocumentprocessor.cpp
@@ -1,0 +1,223 @@
+/**************************************************************************
+**
+** Copyright (c) 2026 Marcel Petrick
+**
+** This file is part of the SpellChecker Plugin, a Qt Creator plugin.
+**
+** The SpellChecker Plugin is free software: you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public License as
+** published by the Free Software Foundation, either version 3 of the
+** License, or (at your option) any later version.
+**
+** The SpellChecker Plugin is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with the SpellChecker Plugin.  If not, see <http://www.gnu.org/licenses/>.
+****************************************************************************/
+
+#include "../../src/Parsers/QmlParser/qmldocumentprocessor.h"
+
+#include <QtTest>
+
+using namespace SpellChecker;
+using namespace SpellChecker::QmlSpellChecker::Internal;
+
+namespace {
+
+/*! \brief Convert the plugin WordList container into an ordered QList for tests.
+ * \param[in] wordList Words returned by the parser.
+ * \return Words copied into a QList. */
+QList<Word> allWords( const WordList& wordList )
+{
+  QList<Word> words;
+  for( const Word& word: wordList ) {
+    words << word;
+  }
+  return words;
+}
+
+/*! \brief Query whether a parsed word list contains a word.
+ * \param[in] words Words to search.
+ * \param[in] text Text to find.
+ * \return true when a word with matching text exists. */
+bool containsWord( const QList<Word>& words, const QString& text )
+{
+  return std::any_of( words.cbegin(), words.cend(), [&text]( const Word& word ) {
+    return word.text == text;
+  } );
+}
+
+/*! \brief Find a word by text.
+ * \param[in] words Words to search.
+ * \param[in] text Text to find.
+ * \return Matching word, or a default word if no match exists. */
+Word findWord( const QList<Word>& words, const QString& text )
+{
+  const auto iter = std::find_if( words.cbegin(), words.cend(), [&text]( const Word& word ) {
+    return word.text == text;
+  } );
+  return iter == words.cend() ? Word{} : *iter;
+}
+
+} // namespace
+
+/*! \brief Verifies extraction and filtering by the QML document processor.
+ *
+ * This class tests QML comments and literals without requiring a running Qt
+ * Creator instance.
+ */
+class QmlDocumentProcessorTest
+  : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void extractsCommentsAndStringLiterals();
+  void ignoresQmlCodeTokens();
+  void supportsMultilineCommentsAndTemplateLiterals();
+  void extractsInlineCommentAfterStringLiteral();
+  void filtersCommonFalsePositives();
+  void honorsCheckModeSettings();
+};
+
+void QmlDocumentProcessorTest::extractsCommentsAndStringLiterals()
+{
+  QmlParserSettings settings;
+  const QString source = QStringLiteral(
+    "Item {\n"
+    "    text: \"Hello visible wurld\"\n"
+    "    // Commant here\n"
+    "}\n" );
+
+  const QList<Word> words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+
+  QVERIFY( containsWord( words, QStringLiteral( "Hello" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "visible" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "wurld" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "Commant" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "here" ) ) );
+
+  const Word hello = findWord( words, QStringLiteral( "Hello" ) );
+  QCOMPARE( hello.lineNumber, 2 );
+  QCOMPARE( hello.columnNumber, 12 );
+  QCOMPARE( hello.inComment, false );
+
+  const Word comment = findWord( words, QStringLiteral( "Commant" ) );
+  QCOMPARE( comment.lineNumber, 3 );
+  QCOMPARE( comment.columnNumber, 8 );
+  QCOMPARE( comment.inComment, true );
+}
+
+void QmlDocumentProcessorTest::ignoresQmlCodeTokens()
+{
+  QmlParserSettings settings;
+  const QString source = QStringLiteral(
+    "import QtQuick\n"
+    "Rectangle {\n"
+    "    id: rootItem\n"
+    "    property string internalName: model.displayName\n"
+    "    text: qsTr(\"Visible label\")\n"
+    "}\n" );
+
+  const QList<Word> words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+
+  QVERIFY( containsWord( words, QStringLiteral( "Visible" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "label" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "Rectangle" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "root" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "Item" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "internal" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "Name" ) ) );
+}
+
+void QmlDocumentProcessorTest::supportsMultilineCommentsAndTemplateLiterals()
+{
+  QmlParserSettings settings;
+  const QString source = QStringLiteral(
+    "Item {\n"
+    "    /* First commant\n"
+    "       second line */\n"
+    "    property string value: `Template literal text`\n"
+    "}\n" );
+
+  const QList<Word> words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+
+  QVERIFY( containsWord( words, QStringLiteral( "First" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "commant" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "second" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "Template" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "literal" ) ) );
+
+  const Word second = findWord( words, QStringLiteral( "second" ) );
+  QCOMPARE( second.lineNumber, 3 );
+  QCOMPARE( second.inComment, true );
+}
+
+void QmlDocumentProcessorTest::extractsInlineCommentAfterStringLiteral()
+{
+  QmlParserSettings settings;
+  const QString source = QStringLiteral(
+    "Window {\n"
+    "    color: \"#2c3e50\" // Darker background for a polisehed appiarance.\n"
+    "}\n" );
+
+  const QList<Word> words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+
+  QVERIFY( containsWord( words, QStringLiteral( "Darker" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "background" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "polisehed" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "appiarance" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "#2c3e50" ) ) );
+
+  const Word misspelled = findWord( words, QStringLiteral( "polisehed" ) );
+  QCOMPARE( misspelled.lineNumber, 2 );
+  QCOMPARE( misspelled.inComment, true );
+}
+
+void QmlDocumentProcessorTest::filtersCommonFalsePositives()
+{
+  QmlParserSettings settings;
+  const QString source = QStringLiteral(
+    "Item {\n"
+    "    text: \"Visit https://example.org/path and test@example.org plus camelCase_word 1234 #ffaa00 OK\"\n"
+    "}\n" );
+
+  const QList<Word> words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+
+  QVERIFY( containsWord( words, QStringLiteral( "Visit" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "camel" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "Case" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "word" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "https://example.org/path" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "test@example.org" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "1234" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "#ffaa00" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "OK" ) ) );
+}
+
+void QmlDocumentProcessorTest::honorsCheckModeSettings()
+{
+  QmlParserSettings settings;
+  settings.whatToCheck = QmlParserSettings::CheckComments;
+
+  const QString source = QStringLiteral(
+    "Item {\n"
+    "    text: \"Literalword\"\n"
+    "    // Commentword\n"
+    "}\n" );
+
+  QList<Word> words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+  QVERIFY( containsWord( words, QStringLiteral( "Commentword" ) ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "Literalword" ) ) );
+
+  settings.whatToCheck = QmlParserSettings::CheckStringLiterals;
+  words = allWords( QmlDocumentProcessor::parseSource( QStringLiteral( "Main.qml" ), source, settings ) );
+  QVERIFY( !containsWord( words, QStringLiteral( "Commentword" ) ) );
+  QVERIFY( containsWord( words, QStringLiteral( "Literalword" ) ) );
+}
+
+QTEST_GUILESS_MAIN( QmlDocumentProcessorTest )
+#include "tst_qmldocumentprocessor.moc"


### PR DESCRIPTION
Add a dedicated QML document parser alongside the existing C++ parser. This addresses a long-standing gap by checking user-facing QML text without treating QML and JavaScript code identifiers as prose.

## The implementation:
- scans line comments, block comments, quoted strings, and template literals
- preserves file, line, column, offset, length, and token classification
- filters URLs, email addresses, numbers, color values, and all-caps words
- splits compound candidates at underscores, dots, numbers, and camelCase boundaries
- supports current-file and project-wide operation with background processing
- reparses edited documents with debouncing and cancels stale or shutdown work
- provides independent settings for comments and string literals
- adds the Spell Check context menu to the QML editor
- registers the parser and required QML dependencies with Qt Creator
- documents behavior, configuration, and lexical-scanner limitations
- adds focused tests for extraction, filtering, modes, and source positions
- sets the plugin version to 3.12.2

This contribution is intended as a helpful addition for a feature that has been missing for years. It is my first Qt Creator plugin contribution, and I am happy to build humbly on the work of Carel Combrink @CJCombrink  and the other contributors.

Tested with Qt Creator 19.0.2 using the build helper from mpe/qml_check. The QML parser test suite passes with /usr/bin/ctest.

Solves #196 